### PR TITLE
Fix build with PostgreSQL 9.3devel

### DIFF
--- a/alert.c
+++ b/alert.c
@@ -1,6 +1,9 @@
 #include "postgres.h"
 #include "executor/spi.h"
 
+#if PG_VERSION_NUM >= 90300
+#include "access/htup_details.h"
+#endif
 #include "catalog/pg_type.h"
 #include "commands/trigger.h"
 #include "funcapi.h"

--- a/file.c
+++ b/file.c
@@ -5,6 +5,9 @@
 
 #include "executor/spi.h"
 
+#if PG_VERSION_NUM >= 90300
+#include "access/htup_details.h"
+#endif
 #include "catalog/pg_type.h"
 #include "fmgr.h"
 #include "funcapi.h"

--- a/pipe.c
+++ b/pipe.c
@@ -1,6 +1,9 @@
 #include "postgres.h"
 #include "funcapi.h"
 #include "fmgr.h"
+#if PG_VERSION_NUM >= 90300
+#include "access/htup_details.h"
+#endif
 #include "storage/shmem.h"
 #include "utils/memutils.h"
 #include "utils/timestamp.h"

--- a/putline.c
+++ b/putline.c
@@ -1,6 +1,9 @@
 #include "postgres.h"
 #include "funcapi.h"
 #include "access/heapam.h"
+#if PG_VERSION_NUM >= 90300
+#include "access/htup_details.h"
+#endif
 #include "catalog/pg_type.h"
 #include "lib/stringinfo.h"
 

--- a/sqlscan.l
+++ b/sqlscan.l
@@ -25,8 +25,15 @@ extern PGDLLIMPORT const int	NumScanKeywords;
 #define ScanKeywordLookupArgs
 #endif
 
+/* Avoid exit() on fatal scanner errors (a bit ugly -- see yy_fatal_error) */
 #undef fprintf
-#define fprintf(file, fmt, msg)  ereport(ERROR, (errmsg_internal("%s", msg)))
+#define fprintf(file, fmt, msg)  fprintf_to_ereport(fmt, msg)
+
+static void
+fprintf_to_ereport(const char *fmt, const char *msg)
+{
+	ereport(ERROR, (errmsg_internal("%s", msg)));
+}
 
 static int		xcdepth = 0;	/* depth of nesting in slash-star comments */
 static char    *dolqstart;      /* current $foo$ quote start string */
@@ -35,9 +42,6 @@ static bool extended_string = false;
 
 /* No reason to constrain amount of data slurped */
 #define YY_READ_BUF_SIZE 16777216
-
-/* Avoid exit() on fatal scanner errors (a bit ugly -- see yy_fatal_error) */
-#define fprintf(file, fmt, msg)  ereport(ERROR, (errmsg_internal("%s", msg)))
 
 /* Handles to the buffer that the lexer uses internally */
 


### PR DESCRIPTION
Some needed declarations have been moved to the new header
htup_details.h.

Adjust hack in scanner file for changed definition of ereport().
