### PR TITLE
Fix compilation error with Bison >=2.6

### DIFF
--- a/sqlparse.y
+++ b/sqlparse.y
@@ -1,6 +1,5 @@
 %{
 
-#define YYPARSE_PARAM result  /* need this to pass a pointer (void *) to yyparse */
 #define YYDEBUG 1
 
 #define YYLLOC_DEFAULT(Current, Rhs, N) \
@@ -45,7 +44,7 @@ extern int yylex(void);      /* defined as fdate_yylex in fdatescan.l */
 static char *scanbuf;
 static int	scanbuflen;
 
-void orafce_sql_yyerror(const char *message);
+void orafce_sql_yyerror(List **result, const char *message);
 
 
 #define YYLTYPE		int
@@ -55,6 +54,7 @@ void orafce_sql_yyerror(const char *message);
 %}
 %name-prefix="orafce_sql_yy" 
 %locations
+%parse-param {List **result}
 
 %union
 {

--- a/sqlscan.l
+++ b/sqlscan.l
@@ -613,7 +613,7 @@ other			.
 
 					BEGIN(INITIAL);
 					if (literallen == 0)
-						yyerror("zero-length delimited identifier");
+						yyerror(NULL, "zero-length delimited identifier");
 					ident = litbufdup();
 					if (literallen >= NAMEDATALEN)
 						truncate_identifier(ident, literallen, true);
@@ -729,7 +729,7 @@ other			.
 					 * a syntactic mistake anyway.
 					 */
 					if (nchars >= NAMEDATALEN)
-						yyerror("operator too long");
+						yyerror(NULL, "operator too long");
 
 					/* Convert "!=" operator to "<>" for compatibility */
 					yylval.val.modificator = NULL;
@@ -898,7 +898,7 @@ lexer_errposition(void)
  * be misleading!
  */
 void
-yyerror(const char *message)
+yyerror(List **result, const char *message)
 {
 	const char *loc = scanbuf + yylloc;
 


### PR DESCRIPTION
Because of the way newer Bison versions arrange the prototypes in the generated header files, there will be a compiler error because of inconsistent prototypes if YYPARSE_PARAM is used.  Move #define of YYPARSE_PARAM into header file so that the prototype for orafce_sql_yyparse() is consistent.

See also http://bugs.debian.org/cgi-bin/bugreport.cgi?bug=710633.
