### PR TITLE
Fix regression test issues till 8.3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,20 @@ EXTENSION = orafce
 DATA_built = orafunc.sql
 DATA = uninstall_orafunc.sql orafce--3.0.5.sql orafce--unpackaged--3.0.5.sql
 DOCS = README.asciidoc COPYRIGHT.orafunc INSTALL.orafunc
-REGRESS = orafunc dbms_output files dbms_utility
-REGRESS_OPTS = --load-language=plpgsql --load-extension=orafce --schedule=parallel_schedule
+
+PG_CONFIG ?= pg_config
+
+# version as a number, e.g. 9.1.4 -> 901
+VERSION := $(shell $(PG_CONFIG) --version | awk '{print $$2}')
+INTVERSION := $(shell echo $$(($$(echo $(VERSION) | sed 's/\([[:digit:]]\{1,\}\)\.\([[:digit:]]\{1,\}\).*/\1*100+\2/' ))))
+
+REGRESS = orafunc dbms_output dbms_utility files
+
+ifeq ($(shell echo $$(($(INTVERSION) >= 804))),1)
+REGRESS += aggregates nlssort dbms_random
+endif
+
+REGRESS_OPTS = --load-language=plpgsql --schedule=parallel_schedule
 
 EXTRA_CLEAN = sqlparse.c sqlparse.h sqlscan.c y.tab.c y.tab.h orafunc.sql.in
 

--- a/expected/aggregates.out
+++ b/expected/aggregates.out
@@ -1,0 +1,120 @@
+-- Tests for the aggregate listagg
+SELECT listagg(i::text) from generate_series(1,3) g(i);
+ listagg 
+---------
+ 123
+(1 row)
+
+SELECT listagg(i::text, ',') from generate_series(1,3) g(i);
+ listagg 
+---------
+ 1,2,3
+(1 row)
+
+SELECT coalesce(listagg(i::text), '<NULL>') from (SELECT ''::text) g(i);
+ coalesce 
+----------
+ 
+(1 row)
+
+SELECT coalesce(listagg(i::text), '<NULL>') from generate_series(1,0) g(i);
+ coalesce 
+----------
+ <NULL>
+(1 row)
+
+-- Tests for the aggregate median( real | double )
+CREATE FUNCTION checkMedianRealOdd()  RETURNS real AS $$
+DECLARE
+ med real;
+
+BEGIN
+	CREATE TABLE median_test (salary real);
+        INSERT INTO median_test VALUES (4500);
+        INSERT INTO median_test VALUES (NULL);
+        INSERT INTO median_test VALUES (2100);
+        INSERT INTO median_test VALUES (3600);
+        INSERT INTO median_test VALUES (4000);
+        SELECT into med median(salary) from median_test;
+        DROP TABLE median_test;
+        return med;
+        
+END;
+$$ LANGUAGE plpgsql;
+CREATE FUNCTION checkMedianRealEven() RETURNS real AS $$
+DECLARE
+ med real;
+
+BEGIN
+        CREATE TABLE median_test (salary real);
+        INSERT INTO median_test VALUES (4500);
+        INSERT INTO median_test VALUES (1500);
+        INSERT INTO median_test VALUES (2100);
+        INSERT INTO median_test VALUES (3600);
+        INSERT INTO median_test VALUES (1000);
+        INSERT INTO median_test VALUES (4000);
+        select into med median(salary) from median_test;
+        DROP TABLE median_test;
+        return med;
+END;
+$$ LANGUAGE plpgsql;
+CREATE FUNCTION checkMedianDoubleOdd() RETURNS double precision AS $$
+DECLARE 
+  med double precision;
+BEGIN
+        CREATE TABLE median_test (salary double precision);
+        INSERT INTO median_test VALUES (4500);
+        INSERT INTO median_test VALUES (1500);
+        INSERT INTO median_test VALUES (2100);
+        INSERT INTO median_test VALUES (3600);
+        INSERT INTO median_test VALUES (4000);
+        select into med median(salary) from median_test;
+        DROP TABLE median_test;
+        return med;
+END;
+$$ LANGUAGE plpgsql;
+CREATE FUNCTION checkMedianDoubleEven() RETURNS double precision AS $$
+DECLARE
+ med double precision;
+
+BEGIN
+        CREATE TABLE median_test (salary double precision);
+        INSERT INTO median_test VALUES (4500);
+        INSERT INTO median_test VALUES (1500);
+        INSERT INTO median_test VALUES (2100);
+        INSERT INTO median_test VALUES (3600);
+        INSERT INTO median_test VALUES (4000);
+        INSERT INTO median_test VALUES (1000);
+        select into med median(salary) from median_test;
+        DROP TABLE median_test;
+        return med;
+END;
+$$ LANGUAGE plpgsql;
+SELECT checkMedianRealOdd();
+ checkmedianrealodd 
+--------------------
+               3800
+(1 row)
+
+SELECT checkMedianRealEven();
+ checkmedianrealeven 
+---------------------
+                2850
+(1 row)
+
+SELECT checkMedianDoubleOdd();
+ checkmediandoubleodd 
+----------------------
+                 3600
+(1 row)
+
+SELECT checkMedianDoubleEven();
+ checkmediandoubleeven 
+-----------------------
+                  2850
+(1 row)
+
+DROP FUNCTION checkMedianRealOdd();
+DROP FUNCTION checkMedianRealEven();
+DROP FUNCTION checkMedianDoubleOdd();
+DROP FUNCTION checkMedianDoubleEven();

--- a/expected/dbms_pipe_session_A.out
+++ b/expected/dbms_pipe_session_A.out
@@ -1,5 +1,4 @@
 \set ECHO none
-NOTICE:  role "pipe_test_owner" does not exist, skipping
  pack_message 
 --------------
  
@@ -10,7 +9,6 @@ NOTICE:  role "pipe_test_owner" does not exist, skipping
             0
 (1 row)
 
-NOTICE:  table "temp" does not exist, skipping
  createimplicitpipe 
 --------------------
  

--- a/expected/dbms_pipe_session_B.out
+++ b/expected/dbms_pipe_session_B.out
@@ -11,7 +11,7 @@ NOTICE:  RECEIVE 13: Tue Jan 01 09:00:00 2013 PST
 NOTICE:  RECEIVE 9: 12345.6789
 NOTICE:  RECEIVE 9: 12345
 NOTICE:  RECEIVE 9: 99999999999
-NOTICE:  RECEIVE 23: \x123456
+NOTICE:  RECEIVE 23: \201
 NOTICE:  RECEIVE 24: (2,rob)
  receivefrom 
 -------------
@@ -25,7 +25,7 @@ NOTICE:  RECEIVE 13: Tue Jan 01 09:00:00 2013 PST
 NOTICE:  RECEIVE 9: 12345.6789
 NOTICE:  RECEIVE 9: 12345
 NOTICE:  RECEIVE 9: 99999999999
-NOTICE:  RECEIVE 23: \x123456
+NOTICE:  RECEIVE 23: \201
 NOTICE:  RECEIVE 24: (2,rob)
  bulkreceive 
 -------------
@@ -44,7 +44,7 @@ NOTICE:  RECEIVE 13: Tue Jan 01 09:00:00 2013 PST
 NOTICE:  RECEIVE 9: 12345.6789
 NOTICE:  RECEIVE 9: 12345
 NOTICE:  RECEIVE 9: 99999999999
-NOTICE:  RECEIVE 23: \x123456
+NOTICE:  RECEIVE 23: \201
 NOTICE:  RECEIVE 24: (2,rob)
  receivefrom 
 -------------
@@ -58,9 +58,6 @@ NOTICE:  role "pipe_test_other" does not exist, skipping
 (1 row)
 
 ERROR:  insufficient privilege
-DETAIL:  Insufficient privilege to access pipe
-CONTEXT:  SQL statement "SELECT dbms_pipe.receive_message(pipename,2)"
-PL/pgSQL function receivefrom(text) line 7 at PERFORM
  receive_message 
 -----------------
                0
@@ -73,7 +70,7 @@ NOTICE:  RECEIVE 13: Tue Jan 01 09:00:00 2013 PST
 NOTICE:  RECEIVE 9: 12345.6789
 NOTICE:  RECEIVE 9: 12345
 NOTICE:  RECEIVE 9: 99999999999
-NOTICE:  RECEIVE 23: \x123456
+NOTICE:  RECEIVE 23: \201
 NOTICE:  RECEIVE 24: (2,rob)
  receivefrom 
 -------------
@@ -92,7 +89,7 @@ NOTICE:  RECEIVE 13: Tue Jan 01 09:00:00 2013 PST
 NOTICE:  RECEIVE 9: 12345.6789
 NOTICE:  RECEIVE 9: 12345
 NOTICE:  RECEIVE 9: 99999999999
-NOTICE:  RECEIVE 23: \x123456
+NOTICE:  RECEIVE 23: \201
 NOTICE:  RECEIVE 24: (2,rob)
  receivefrom 
 -------------

--- a/expected/dbms_random.out
+++ b/expected/dbms_random.out
@@ -1,0 +1,91 @@
+-- Tests for package DBMS_RANDOM
+SELECT dbms_random.initialize(8);
+ initialize 
+------------
+ 
+(1 row)
+
+SELECT dbms_random.normal();
+       normal       
+--------------------
+ -0.377877688597918
+(1 row)
+
+SELECT dbms_random.normal();
+      normal       
+-------------------
+ 0.804998041043833
+(1 row)
+
+SELECT dbms_random.seed(8);
+ seed 
+------
+ 
+(1 row)
+
+SELECT dbms_random.random();
+   random   
+------------
+ -632387854
+(1 row)
+
+SELECT dbms_random.seed('test');
+ seed 
+------
+ 
+(1 row)
+
+SELECT dbms_random.string('U',5);
+ string 
+--------
+ XEJGE
+(1 row)
+
+SELECT dbms_random.string('P',2);
+ string 
+--------
+ T9
+(1 row)
+
+SELECT dbms_random.string('x',4);
+ string 
+--------
+ FVGL
+(1 row)
+
+SELECT dbms_random.string('a',2);
+ string 
+--------
+ AZ
+(1 row)
+
+SELECT dbms_random.string('l',3);
+ string 
+--------
+ hmo
+(1 row)
+
+SELECT dbms_random.seed(5);
+ seed 
+------
+ 
+(1 row)
+
+SELECT dbms_random.value();
+       value       
+-------------------
+ 0.274745596107095
+(1 row)
+
+SELECT dbms_random.value(10,15);
+      value       
+------------------
+ 10.2323388238437
+(1 row)
+
+SELECT dbms_random.terminate();
+ terminate 
+-----------
+ 
+(1 row)
+

--- a/expected/dbms_utility.out
+++ b/expected/dbms_utility.out
@@ -1,22 +1,16 @@
 \set ECHO none
-              checkhexcallstack               
-----------------------------------------------
- ----- PL/pgSQL Call Stack -----             +
-   object     line  object                   +
-   handle   number  name                     +
-        0           function anonymous object+
-         5  function checkhexcallstack()
+checkhexcallstack
+----- PL/pgSQL Call Stack -----
+  object     line  object
+  handle   number  name
+       0           function anonymous object
+       0          function checkhexcallstack
 (1 row)
-
-              checkintcallstack               
-----------------------------------------------
-        0           function anonymous object+
-         5  function checkintcallstack()
+checkintcallstack
+       0           function anonymous object
+       0          function checkintcallstack
 (1 row)
-
-   checkintunpaddedcallstack    
---------------------------------
- 0,,anonymous object           +
- ,5,checkintunpaddedcallstack()
+checkintunpaddedcallstack
+0,,anonymous object
+0,,checkintunpaddedcallstack
 (1 row)
-

--- a/expected/files.out
+++ b/expected/files.out
@@ -1,4 +1,6 @@
-\set ECHO none 
+SET client_min_messages = NOTICE;
+\set VERBOSITY terse
+\set ECHO all
 CREATE OR REPLACE FUNCTION gen_file(dir text) RETURNS void AS $$
 DECLARE
   f utl_file.file_type;
@@ -75,13 +77,13 @@ BEGIN
       RAISE NOTICE 'is_open = %', utl_file.is_open(f);
   END;
 $$ LANGUAGE plpgsql;
-SELECT EXISTS(SELECT * FROM pg_catalog.pg_class where relname='utl_file_dir');
+SELECT EXISTS(SELECT * FROM pg_catalog.pg_class where relname='utl_file_dir') AS exists;
  exists 
 --------
  t
 (1 row)
 
-SELECT EXISTS(SELECT * FROM pg_catalog.pg_type where typname='file_type');
+SELECT EXISTS(SELECT * FROM pg_catalog.pg_type where typname='file_type') AS exists;
  exists 
 --------
  t
@@ -90,13 +92,10 @@ SELECT EXISTS(SELECT * FROM pg_catalog.pg_type where typname='file_type');
 -- Trying to access a file in path not registered
 SELECT utl_file.fopen(utl_file.tmpdir(),'sample.txt','r');
 ERROR:  UTL_FILE_INVALID_PATH
-DETAIL:  you cannot access locality
-HINT:  locality is not found in utl_file_dir table
 -- Trying to access file in a non-existent directory
 INSERT INTO utl_file.utl_file_dir(dir) VALUES('test_tmp_dir');
 SELECT utl_file.fopen('test_tmp_dir','file.txt.','w');
 ERROR:  UTL_FILE_INVALID_PATH
-DETAIL:  No such file or directory
 DELETE FROM utl_file.utl_file_dir WHERE dir LIKE 'test_tmp_dir';
 -- Add tmpdir() to utl_file_dir table
 INSERT INTO utl_file.utl_file_dir(dir) VALUES(utl_file.tmpdir());
@@ -109,7 +108,6 @@ SELECT * from utl_file.utl_file_dir;
 -- Trying to access non-existent file
 SELECT utl_file.fopen(utl_file.tmpdir(),'non_existent_file.txt','r');
 ERROR:  UTL_FILE_INVALID_PATH
-DETAIL:  No such file or directory
 --Other test cases
 SELECT gen_file(utl_file.tmpdir());
  gen_file 

--- a/expected/init.out
+++ b/expected/init.out
@@ -1,0 +1,1 @@
+\set ECHO none

--- a/expected/nlssort.out
+++ b/expected/nlssort.out
@@ -1,0 +1,60 @@
+-- Tests for nlssort
+\set ECHO none
+  name  
+--------
+ brown
+ Purple
+ red
+ yellow
+(4 rows)
+
+  name  
+--------
+ Purple
+ brown
+ red
+ yellow
+(4 rows)
+
+ set_nls_sort 
+--------------
+ 
+(1 row)
+
+ERROR:  failed to set the requested LC_COLLATE value [invalid]
+CONTEXT:  SQL function "nlssort" statement 1
+ set_nls_sort 
+--------------
+ 
+(1 row)
+
+  name  
+--------
+ Purple
+ brown
+ red
+ yellow
+(4 rows)
+
+ set_nls_sort 
+--------------
+ 
+(1 row)
+
+  name  
+--------
+ brown
+ Purple
+ red
+ yellow
+(4 rows)
+
+  name  
+--------
+ brown
+ Purple
+ red
+ yellow
+ 
+(5 rows)
+

--- a/expected/orafunc.out
+++ b/expected/orafunc.out
@@ -1127,100 +1127,100 @@ select decode('2009-02-05 01:02:03'::timestamp, '2009-02-05 01:02:03', 'ok');
 (1 row)
 
 -- For type 'bpchar'
-select decode('a'::bpchar(2), 'a'::bpchar(2),'postgres'::bpchar(15));
-     decode      
------------------
- postgres       
+select decode('a'::bpchar, 'a'::bpchar,'postgres'::bpchar);
+  decode  
+----------
+ postgres
 (1 row)
 
-select decode('c'::bpchar(2), 'a'::bpchar(2),'postgres'::bpchar(15));
+select decode('c'::bpchar, 'a'::bpchar,'postgres'::bpchar);
  decode 
 --------
  
 (1 row)
 
-select decode('a'::bpchar(2), 'a'::bpchar(2),'postgres'::bpchar(15),'default value'::bpchar(15));
-     decode      
------------------
- postgres       
+select decode('a'::bpchar, 'a'::bpchar,'postgres'::bpchar,'default value'::bpchar);
+  decode  
+----------
+ postgres
 (1 row)
 
-select decode('c', 'a'::bpchar(2),'postgres'::bpchar(15),'default value'::bpchar(15));
-     decode      
------------------
- default value  
+select decode('c', 'a'::bpchar,'postgres'::bpchar,'default value'::bpchar);
+    decode     
+---------------
+ default value
 (1 row)
 
-select decode('a'::bpchar(2), 'a'::bpchar(2),'postgres'::bpchar(15),'b'::bpchar(2),'database'::bpchar(15));
-     decode      
------------------
- postgres       
+select decode('a'::bpchar, 'a'::bpchar,'postgres'::bpchar,'b'::bpchar,'database'::bpchar);
+  decode  
+----------
+ postgres
 (1 row)
 
-select decode('d'::bpchar(2), 'a'::bpchar(2),'postgres'::bpchar(15),'b'::bpchar(2),'database'::bpchar(15));
+select decode('d'::bpchar, 'a'::bpchar,'postgres'::bpchar,'b'::bpchar,'database'::bpchar);
  decode 
 --------
  
 (1 row)
 
-select decode('a'::bpchar(2), 'a'::bpchar(2),'postgres'::bpchar(15),'b'::bpchar(2),'database'::bpchar(15),'default value'::bpchar(15));
-     decode      
------------------
- postgres       
+select decode('a'::bpchar, 'a'::bpchar,'postgres'::bpchar,'b'::bpchar,'database'::bpchar,'default value'::bpchar);
+  decode  
+----------
+ postgres
 (1 row)
 
-select decode('d'::bpchar(2), 'a'::bpchar(2),'postgres'::bpchar(15),'b'::bpchar(2),'database'::bpchar(15),'default value'::bpchar(15));
-     decode      
------------------
- default value  
+select decode('d'::bpchar, 'a'::bpchar,'postgres'::bpchar,'b'::bpchar,'database'::bpchar,'default value'::bpchar);
+    decode     
+---------------
+ default value
 (1 row)
 
-select decode('a'::bpchar(2), 'a'::bpchar(2),'postgres'::bpchar(15),'b'::bpchar(2),'database'::bpchar(15), 'c'::bpchar(2), 'system'::bpchar(15));
-     decode      
------------------
- postgres       
+select decode('a'::bpchar, 'a'::bpchar,'postgres'::bpchar,'b'::bpchar,'database'::bpchar, 'c'::bpchar, 'system'::bpchar);
+  decode  
+----------
+ postgres
 (1 row)
 
-select decode('d'::bpchar(2), 'a'::bpchar(2),'postgres'::bpchar(15),'b'::bpchar(2),'database'::bpchar(15), 'c'::bpchar(2), 'system'::bpchar(15));
+select decode('d'::bpchar, 'a'::bpchar,'postgres'::bpchar,'b'::bpchar,'database'::bpchar, 'c'::bpchar, 'system'::bpchar);
  decode 
 --------
  
 (1 row)
 
-select decode('a'::bpchar(2), 'a'::bpchar(2),'postgres'::bpchar(15),'b'::bpchar(2),'database'::bpchar(15), 'c'::bpchar(2), 'system'::bpchar(15),'default value'::bpchar(15));
-     decode      
------------------
- postgres       
+select decode('a'::bpchar, 'a'::bpchar,'postgres'::bpchar,'b'::bpchar,'database'::bpchar, 'c'::bpchar, 'system'::bpchar,'default value'::bpchar);
+  decode  
+----------
+ postgres
 (1 row)
 
-select decode('d'::bpchar(2), 'a'::bpchar(2),'postgres'::bpchar(15),'b'::bpchar(2),'database'::bpchar(15), 'c'::bpchar(2), 'system'::bpchar(15),'default value'::bpchar(15));
-     decode      
------------------
- default value  
+select decode('d'::bpchar, 'a'::bpchar,'postgres'::bpchar,'b'::bpchar,'database'::bpchar, 'c'::bpchar, 'system'::bpchar,'default value'::bpchar);
+    decode     
+---------------
+ default value
 (1 row)
 
-select decode(NULL, 'a'::bpchar(2), 'postgres'::bpchar(15), NULL,'database'::bpchar(15));
-     decode      
------------------
- database       
+select decode(NULL, 'a'::bpchar, 'postgres'::bpchar, NULL,'database'::bpchar);
+  decode  
+----------
+ database
 (1 row)
 
-select decode(NULL, 'a'::bpchar(2), 'postgres'::bpchar(15), 'b'::bpchar(2),'database'::bpchar(15));
+select decode(NULL, 'a'::bpchar, 'postgres'::bpchar, 'b'::bpchar,'database'::bpchar);
  decode 
 --------
  
 (1 row)
 
-select decode(NULL, 'a'::bpchar(2), 'postgres'::bpchar(15), NULL,'database'::bpchar(15),'default value'::bpchar(15));
-     decode      
------------------
- database       
+select decode(NULL, 'a'::bpchar, 'postgres'::bpchar, NULL,'database'::bpchar,'default value'::bpchar);
+  decode  
+----------
+ database
 (1 row)
 
-select decode(NULL, 'a'::bpchar(2), 'postgres'::bpchar(15), 'b'::bpchar(2),'database'::bpchar(15),'default value'::bpchar(15));
-     decode      
------------------
- default value  
+select decode(NULL, 'a'::bpchar, 'postgres'::bpchar, 'b'::bpchar,'database'::bpchar,'default value'::bpchar);
+    decode     
+---------------
+ default value
 (1 row)
 
 -- For type 'bigint'
@@ -2211,121 +2211,6 @@ SELECT dump('2009-10-10'::timestamp) ~ E'^Typ=1114 Len=8: \\d+(,\\d+){7}$' AS t;
  t
 (1 row)
 
-select listagg(i::text) from generate_series(1,3) g(i);
- listagg 
----------
- 123
-(1 row)
-
-select listagg(i::text, ',') from generate_series(1,3) g(i);
- listagg 
----------
- 1,2,3
-(1 row)
-
-select coalesce(listagg(i::text), '<NULL>') from (SELECT ''::text) g(i);
- coalesce 
-----------
- 
-(1 row)
-
-select coalesce(listagg(i::text), '<NULL>') from generate_series(1,0) g(i);
- coalesce 
-----------
- <NULL>
-(1 row)
-
--- Tests for package DBMS_RANDOM
-SELECT dbms_random.initialize(8);
- initialize 
-------------
- 
-(1 row)
-
-SELECT dbms_random.normal();
-       normal       
---------------------
- -0.377877688597918
-(1 row)
-
-SELECT dbms_random.normal();
-      normal       
--------------------
- 0.804998041043833
-(1 row)
-
-SELECT dbms_random.seed(8);
- seed 
-------
- 
-(1 row)
-
-SELECT dbms_random.random();
-   random   
-------------
- -632387854
-(1 row)
-
-SELECT dbms_random.seed('test');
- seed 
-------
- 
-(1 row)
-
-SELECT dbms_random.string('U',5);
- string 
---------
- XEJGE
-(1 row)
-
-SELECT dbms_random.string('P',2);
- string 
---------
- T9
-(1 row)
-
-SELECT dbms_random.string('x',4);
- string 
---------
- FVGL
-(1 row)
-
-SELECT dbms_random.string('a',2);
- string 
---------
- AZ
-(1 row)
-
-SELECT dbms_random.string('l',3);
- string 
---------
- hmo
-(1 row)
-
-SELECT dbms_random.seed(5);
- seed 
-------
- 
-(1 row)
-
-SELECT dbms_random.value();
-       value       
--------------------
- 0.274745596107095
-(1 row)
-
-SELECT dbms_random.value(10,15);
-      value       
-------------------
- 10.2323388238437
-(1 row)
-
-SELECT dbms_random.terminate();
- terminate 
------------
- 
-(1 row)
-
 -- Tests for to_multi_byte
 SELECT to_multi_byte('123$test');
   to_multi_byte   
@@ -2346,101 +2231,6 @@ SELECT octet_length(to_multi_byte('abc'));
             9
 (1 row)
 
--- Tests for the aggregate median( real | double )
-CREATE FUNCTION checkMedianRealOdd()  RETURNS real AS $$
-DECLARE
- med real;
-
-BEGIN
-	CREATE TABLE median_test (salary real);
-        INSERT INTO median_test VALUES (4500);
-        INSERT INTO median_test VALUES (NULL);
-        INSERT INTO median_test VALUES (2100);
-        INSERT INTO median_test VALUES (3600);
-        INSERT INTO median_test VALUES (4000);
-        SELECT into med median(salary) from median_test;
-        DROP TABLE median_test;
-        return med;
-        
-END;
-$$ LANGUAGE plpgsql;
-CREATE FUNCTION checkMedianRealEven() RETURNS real AS $$
-DECLARE
- med real;
-
-BEGIN
-        CREATE TABLE median_test (salary real);
-        INSERT INTO median_test VALUES (4500);
-        INSERT INTO median_test VALUES (1500);
-        INSERT INTO median_test VALUES (2100);
-        INSERT INTO median_test VALUES (3600);
-        INSERT INTO median_test VALUES (1000);
-        INSERT INTO median_test VALUES (4000);
-        select into med median(salary) from median_test;
-        DROP TABLE median_test;
-        return med;
-END;
-$$ LANGUAGE plpgsql;
-CREATE FUNCTION checkMedianDoubleOdd() RETURNS double precision AS $$
-DECLARE 
-  med double precision;
-BEGIN
-        CREATE TABLE median_test (salary double precision);
-        INSERT INTO median_test VALUES (4500);
-        INSERT INTO median_test VALUES (1500);
-        INSERT INTO median_test VALUES (2100);
-        INSERT INTO median_test VALUES (3600);
-        INSERT INTO median_test VALUES (4000);
-        select into med median(salary) from median_test;
-        DROP TABLE median_test;
-        return med;
-END;
-$$ LANGUAGE plpgsql;
-CREATE FUNCTION checkMedianDoubleEven() RETURNS double precision AS $$
-DECLARE
- med double precision;
-
-BEGIN
-        CREATE TABLE median_test (salary double precision);
-        INSERT INTO median_test VALUES (4500);
-        INSERT INTO median_test VALUES (1500);
-        INSERT INTO median_test VALUES (2100);
-        INSERT INTO median_test VALUES (3600);
-        INSERT INTO median_test VALUES (4000);
-        INSERT INTO median_test VALUES (1000);
-        select into med median(salary) from median_test;
-        DROP TABLE median_test;
-        return med;
-END;
-$$ LANGUAGE plpgsql;
-SELECT checkMedianRealOdd();
- checkmedianrealodd 
---------------------
-               3800
-(1 row)
-
-SELECT checkMedianRealEven();
- checkmedianrealeven 
----------------------
-                2850
-(1 row)
-
-SELECT checkMedianDoubleOdd();
- checkmediandoubleodd 
-----------------------
-                 3600
-(1 row)
-
-SELECT checkMedianDoubleEven();
- checkmediandoubleeven 
------------------------
-                  2850
-(1 row)
-
-DROP FUNCTION checkMedianRealOdd();
-DROP FUNCTION checkMedianRealEven();
-DROP FUNCTION checkMedianDoubleOdd();
-DROP FUNCTION checkMedianDoubleEven();
 -- Tests for round(TIMESTAMP WITH TIME ZONE)
 select round(TIMESTAMP WITH TIME ZONE'12/08/1990 05:35:25','YEAR') = '1991-01-01 00:00:00';
  ?column? 
@@ -2574,80 +2364,3 @@ select to_date('J2451187');
  1999-01-08
 (1 row)
 
--- Tests for nlssort
-DROP DATABASE IF EXISTS db_sort;
-CREATE DATABASE db_sort WITH TEMPLATE = template0 ENCODING='SQL_ASCII' LC_COLLATE='C' LC_CTYPE='C';
-\c db_sort
-CREATE EXTENSION orafce;
-CREATE TABLE test_sort (name TEXT);
-INSERT INTO test_sort VALUES ('red'), ('brown'), ('yellow'), ('Purple');
-SELECT * FROM test_sort ORDER BY NLSSORT(name, 'en_US.utf8');
-  name  
---------
- brown
- Purple
- red
- yellow
-(4 rows)
-
-SELECT * FROM test_sort ORDER BY NLSSORT(name, '');
-  name  
---------
- Purple
- brown
- red
- yellow
-(4 rows)
-
-SELECT set_nls_sort('invalid');
- set_nls_sort 
---------------
- 
-(1 row)
-
-SELECT * FROM test_sort ORDER BY NLSSORT(name);
-ERROR:  failed to set the requested LC_COLLATE value [invalid]
-CONTEXT:  SQL function "nlssort" statement 1
-SELECT set_nls_sort('');
- set_nls_sort 
---------------
- 
-(1 row)
-
-SELECT * FROM test_sort ORDER BY NLSSORT(name);
-  name  
---------
- Purple
- brown
- red
- yellow
-(4 rows)
-
-SELECT set_nls_sort('en_US.utf8');
- set_nls_sort 
---------------
- 
-(1 row)
-
-SELECT * FROM test_sort ORDER BY NLSSORT(name);
-  name  
---------
- brown
- Purple
- red
- yellow
-(4 rows)
-
-INSERT INTO test_sort VALUES(NULL);
-SELECT * FROM test_sort ORDER BY NLSSORT(name);
-  name  
---------
- brown
- Purple
- red
- yellow
- 
-(5 rows)
-
-\c contrib_regression
-DROP DATABASE db_sort;

--- a/parallel_schedule
+++ b/parallel_schedule
@@ -1,2 +1,3 @@
+test: init
 test: dbms_pipe_session_A dbms_pipe_session_B
 test: dbms_alert_session_A dbms_alert_session_B dbms_alert_session_C

--- a/sql/aggregates.sql
+++ b/sql/aggregates.sql
@@ -1,0 +1,88 @@
+-- Tests for the aggregate listagg
+SELECT listagg(i::text) from generate_series(1,3) g(i);
+SELECT listagg(i::text, ',') from generate_series(1,3) g(i);
+SELECT coalesce(listagg(i::text), '<NULL>') from (SELECT ''::text) g(i);
+SELECT coalesce(listagg(i::text), '<NULL>') from generate_series(1,0) g(i);
+
+-- Tests for the aggregate median( real | double )
+CREATE FUNCTION checkMedianRealOdd()  RETURNS real AS $$
+DECLARE
+ med real;
+
+BEGIN
+	CREATE TABLE median_test (salary real);
+        INSERT INTO median_test VALUES (4500);
+        INSERT INTO median_test VALUES (NULL);
+        INSERT INTO median_test VALUES (2100);
+        INSERT INTO median_test VALUES (3600);
+        INSERT INTO median_test VALUES (4000);
+        SELECT into med median(salary) from median_test;
+        DROP TABLE median_test;
+        return med;
+        
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE FUNCTION checkMedianRealEven() RETURNS real AS $$
+DECLARE
+ med real;
+
+BEGIN
+        CREATE TABLE median_test (salary real);
+        INSERT INTO median_test VALUES (4500);
+        INSERT INTO median_test VALUES (1500);
+        INSERT INTO median_test VALUES (2100);
+        INSERT INTO median_test VALUES (3600);
+        INSERT INTO median_test VALUES (1000);
+        INSERT INTO median_test VALUES (4000);
+        select into med median(salary) from median_test;
+        DROP TABLE median_test;
+        return med;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE FUNCTION checkMedianDoubleOdd() RETURNS double precision AS $$
+DECLARE 
+  med double precision;
+BEGIN
+        CREATE TABLE median_test (salary double precision);
+        INSERT INTO median_test VALUES (4500);
+        INSERT INTO median_test VALUES (1500);
+        INSERT INTO median_test VALUES (2100);
+        INSERT INTO median_test VALUES (3600);
+        INSERT INTO median_test VALUES (4000);
+        select into med median(salary) from median_test;
+        DROP TABLE median_test;
+        return med;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE FUNCTION checkMedianDoubleEven() RETURNS double precision AS $$
+DECLARE
+ med double precision;
+
+BEGIN
+        CREATE TABLE median_test (salary double precision);
+        INSERT INTO median_test VALUES (4500);
+        INSERT INTO median_test VALUES (1500);
+        INSERT INTO median_test VALUES (2100);
+        INSERT INTO median_test VALUES (3600);
+        INSERT INTO median_test VALUES (4000);
+        INSERT INTO median_test VALUES (1000);
+        select into med median(salary) from median_test;
+        DROP TABLE median_test;
+        return med;
+END;
+$$ LANGUAGE plpgsql;
+
+SELECT checkMedianRealOdd();
+SELECT checkMedianRealEven();
+SELECT checkMedianDoubleOdd();
+SELECT checkMedianDoubleEven();
+
+DROP FUNCTION checkMedianRealOdd();
+DROP FUNCTION checkMedianRealEven();
+DROP FUNCTION checkMedianDoubleOdd();
+DROP FUNCTION checkMedianDoubleEven();
+
+

--- a/sql/dbms_pipe_session_A.sql
+++ b/sql/dbms_pipe_session_A.sql
@@ -1,17 +1,18 @@
 \set ECHO none
+SET client_min_messages = warning;
+DROP TABLE IF EXISTS TEMP;
+CREATE TABLE TEMP(id integer,name text);
+INSERT INTO TEMP VALUES (1,'bob'),(2,'rob'),(3,'john');
 
 DROP USER IF EXISTS pipe_test_owner;
 CREATE USER pipe_test_owner WITH CREATEUSER;
+SET client_min_messages = notice;
 
 -- Notify session B of 'pipe_test_owner' having been created.
 SELECT dbms_pipe.pack_message(1);
 SELECT dbms_pipe.send_message('pipe_test_owner_created_notifier');
 -- Create a new connection under the userid of pipe_test_owner
 SET SESSION AUTHORIZATION pipe_test_owner;
-
-DROP TABLE IF EXISTS TEMP;
-CREATE TABLE TEMP(id integer,name text);
-INSERT INTO TEMP VALUES (1,'bob'),(2,'rob'),(3,'john');
 
 /* create an implicit pipe and sends message using 
  * send_message(text,integer,integer)
@@ -44,7 +45,7 @@ BEGIN
         PERFORM send('named_pipe');
         PERFORM dbms_pipe.pack_message(99999999999::bigint);
         PERFORM send('named_pipe');
-        PERFORM dbms_pipe.pack_message('\x123456'::bytea);
+        PERFORM dbms_pipe.pack_message(E'\\201'::bytea);
         PERFORM send('named_pipe');
         SELECT * INTO row FROM TEMP WHERE id=2;
 	PERFORM dbms_pipe.pack_message(row);
@@ -62,7 +63,7 @@ BEGIN
         PERFORM dbms_pipe.pack_message(12345.6789::numeric);
         PERFORM dbms_pipe.pack_message(12345::integer);
         PERFORM dbms_pipe.pack_message(99999999999::bigint);
-        PERFORM dbms_pipe.pack_message('\x123456'::bytea);
+        PERFORM dbms_pipe.pack_message(E'\\201'::bytea);
         SELECT * INTO row FROM TEMP WHERE id=2;
         PERFORM dbms_pipe.pack_message(row);
         PERFORM send('named_pipe_2');
@@ -112,7 +113,7 @@ BEGIN
         PERFORM send(pipename);
         PERFORM dbms_pipe.pack_message(99999999999::bigint);
         PERFORM send(pipename);
-        PERFORM dbms_pipe.pack_message('\x123456'::bytea);
+        PERFORM dbms_pipe.pack_message(E'\\201'::bytea);
         PERFORM send(pipename);
         SELECT * INTO row FROM TEMP WHERE id=2;
         PERFORM dbms_pipe.pack_message(row);

--- a/sql/dbms_pipe_session_B.sql
+++ b/sql/dbms_pipe_session_B.sql
@@ -1,5 +1,5 @@
 \set ECHO none
-
+\set VERBOSITY terse
 --Wait for 'pipe_test_owner' created notification to be sent by session A
 SELECT dbms_pipe.receive_message('pipe_test_owner_created_notifier');
 
@@ -26,7 +26,7 @@ BEGIN
                              WHEN typ=11 THEN dbms_pipe.unpack_message_text()::text
                              WHEN typ=12 THEN dbms_pipe.unpack_message_date()::text
                              WHEN typ=13 THEN dbms_pipe.unpack_message_timestamp()::text
-                             WHEN typ=23 THEN dbms_pipe.unpack_message_bytea()::text
+                             WHEN typ=23 THEN encode(dbms_pipe.unpack_message_bytea(),'escape')::text
                              WHEN typ=24 THEN dbms_pipe.unpack_message_record()::text
                              ELSE NULL
 			END
@@ -57,7 +57,7 @@ BEGIN
                              WHEN typ=11 THEN dbms_pipe.unpack_message_text()::text
                              WHEN typ=12 THEN dbms_pipe.unpack_message_date()::text
                              WHEN typ=13 THEN dbms_pipe.unpack_message_timestamp()::text
-                             WHEN typ=23 THEN dbms_pipe.unpack_message_bytea()::text
+                             WHEN typ=23 THEN encode(dbms_pipe.unpack_message_bytea(),'escape')::text
                              WHEN typ=24 THEN dbms_pipe.unpack_message_record()::text
                              ELSE NULL
                         END

--- a/sql/dbms_random.sql
+++ b/sql/dbms_random.sql
@@ -1,0 +1,16 @@
+-- Tests for package DBMS_RANDOM
+SELECT dbms_random.initialize(8);
+SELECT dbms_random.normal();
+SELECT dbms_random.normal();
+SELECT dbms_random.seed(8);
+SELECT dbms_random.random();
+SELECT dbms_random.seed('test');
+SELECT dbms_random.string('U',5);
+SELECT dbms_random.string('P',2);
+SELECT dbms_random.string('x',4);
+SELECT dbms_random.string('a',2);
+SELECT dbms_random.string('l',3);
+SELECT dbms_random.seed(5);
+SELECT dbms_random.value();
+SELECT dbms_random.value(10,15);
+SELECT dbms_random.terminate();

--- a/sql/dbms_utility.sql
+++ b/sql/dbms_utility.sql
@@ -1,10 +1,13 @@
 \set ECHO none
+\pset format unaligned
 /*
  * Test for dbms_utility.format_call_stack(char mode). 
  * Mode is hex. 
  * The callstack returned is passed to regex_replace function.
- * Regex_replace replaces the function oid from the stack with a blank.
+ * Regex_replace replaces the function oid from the stack with zero.
  * This is done to avoid random results due to different oids generated.
+ * Also the line number and () of the function is removed since it is different
+ * across different pg version.
  */
 
 CREATE OR REPLACE FUNCTION checkHexCallStack() returns text  as $$
@@ -12,7 +15,8 @@ CREATE OR REPLACE FUNCTION checkHexCallStack() returns text  as $$
              stack text;
         BEGIN
              select * INTO stack from dbms_utility.format_call_stack('o');
-             select * INTO stack from regexp_replace(stack,'[ 0-9a-fA-F]{4}[0-9a-fA-F]{4}','','g');
+             select * INTO stack from regexp_replace(stack,'[ 0-9a-fA-F]{4}[0-9a-fA-F]{4}','       0','g');
+             select * INTO stack from regexp_replace(stack,'[45()]','','g');
              return stack;
         END;
 $$ LANGUAGE plpgsql;
@@ -27,7 +31,8 @@ CREATE OR REPLACE FUNCTION checkIntCallStack() returns text  as $$
              stack text;
         BEGIN
              select * INTO stack from dbms_utility.format_call_stack('p');
-             select * INTO stack from regexp_replace(stack,'[ 0-9]{3}[0-9]{5}','','g');
+             select * INTO stack from regexp_replace(stack,'[ 0-9]{3}[0-9]{5}','       0','g');
+             select * INTO stack from regexp_replace(stack,'[45()]','','g');
              return stack;
         END;
 $$ LANGUAGE plpgsql;
@@ -42,7 +47,8 @@ CREATE OR REPLACE FUNCTION checkIntUnpaddedCallStack() returns text  as $$
              stack text;
         BEGIN
              select * INTO stack from dbms_utility.format_call_stack('s');
-             select * INTO stack from regexp_replace(stack,'[0-9]{5,}','','g');
+             select * INTO stack from regexp_replace(stack,'[0-9]{5,}','0','g');
+             select * INTO stack from regexp_replace(stack,'[45()]','','g');
              return stack;
         END;
 $$ LANGUAGE plpgsql;

--- a/sql/files.sql
+++ b/sql/files.sql
@@ -1,5 +1,5 @@
-\set ECHO none 
 SET client_min_messages = NOTICE;
+\set VERBOSITY terse
 \set ECHO all
 CREATE OR REPLACE FUNCTION gen_file(dir text) RETURNS void AS $$
 DECLARE
@@ -80,9 +80,9 @@ BEGIN
   END;
 $$ LANGUAGE plpgsql;
 
-SELECT EXISTS(SELECT * FROM pg_catalog.pg_class where relname='utl_file_dir');
+SELECT EXISTS(SELECT * FROM pg_catalog.pg_class where relname='utl_file_dir') AS exists;
 
-SELECT EXISTS(SELECT * FROM pg_catalog.pg_type where typname='file_type');
+SELECT EXISTS(SELECT * FROM pg_catalog.pg_type where typname='file_type') AS exists;
 
 -- Trying to access a file in path not registered
 SELECT utl_file.fopen(utl_file.tmpdir(),'sample.txt','r');

--- a/sql/init.sql
+++ b/sql/init.sql
@@ -1,0 +1,2 @@
+\set ECHO none
+\i orafunc.sql

--- a/sql/nlssort.sql
+++ b/sql/nlssort.sql
@@ -1,0 +1,20 @@
+-- Tests for nlssort
+\set ECHO none
+SET client_min_messages = warning;
+DROP DATABASE IF EXISTS regression_sort;
+CREATE DATABASE regression_sort WITH TEMPLATE = template0 ENCODING='SQL_ASCII' LC_COLLATE='C' LC_CTYPE='C';
+\c regression_sort
+\set ECHO none
+\i orafunc.sql
+CREATE TABLE test_sort (name TEXT);
+INSERT INTO test_sort VALUES ('red'), ('brown'), ('yellow'), ('Purple');
+SELECT * FROM test_sort ORDER BY NLSSORT(name, 'en_US.utf8');
+SELECT * FROM test_sort ORDER BY NLSSORT(name, '');
+SELECT set_nls_sort('invalid');
+SELECT * FROM test_sort ORDER BY NLSSORT(name);
+SELECT set_nls_sort('');
+SELECT * FROM test_sort ORDER BY NLSSORT(name);
+SELECT set_nls_sort('en_US.utf8');
+SELECT * FROM test_sort ORDER BY NLSSORT(name);
+INSERT INTO test_sort VALUES(NULL);
+SELECT * FROM test_sort ORDER BY NLSSORT(name);

--- a/sql/orafunc.sql
+++ b/sql/orafunc.sql
@@ -215,25 +215,25 @@ select decode('2009-02-05'::date, '2009-02-05', 'ok');
 select decode('2009-02-05 01:02:03'::timestamp, '2009-02-05 01:02:03', 'ok');
 
 -- For type 'bpchar'
-select decode('a'::bpchar(2), 'a'::bpchar(2),'postgres'::bpchar(15));
-select decode('c'::bpchar(2), 'a'::bpchar(2),'postgres'::bpchar(15));
-select decode('a'::bpchar(2), 'a'::bpchar(2),'postgres'::bpchar(15),'default value'::bpchar(15));
-select decode('c', 'a'::bpchar(2),'postgres'::bpchar(15),'default value'::bpchar(15));
+select decode('a'::bpchar, 'a'::bpchar,'postgres'::bpchar);
+select decode('c'::bpchar, 'a'::bpchar,'postgres'::bpchar);
+select decode('a'::bpchar, 'a'::bpchar,'postgres'::bpchar,'default value'::bpchar);
+select decode('c', 'a'::bpchar,'postgres'::bpchar,'default value'::bpchar);
 
-select decode('a'::bpchar(2), 'a'::bpchar(2),'postgres'::bpchar(15),'b'::bpchar(2),'database'::bpchar(15));
-select decode('d'::bpchar(2), 'a'::bpchar(2),'postgres'::bpchar(15),'b'::bpchar(2),'database'::bpchar(15));
-select decode('a'::bpchar(2), 'a'::bpchar(2),'postgres'::bpchar(15),'b'::bpchar(2),'database'::bpchar(15),'default value'::bpchar(15));
-select decode('d'::bpchar(2), 'a'::bpchar(2),'postgres'::bpchar(15),'b'::bpchar(2),'database'::bpchar(15),'default value'::bpchar(15));
+select decode('a'::bpchar, 'a'::bpchar,'postgres'::bpchar,'b'::bpchar,'database'::bpchar);
+select decode('d'::bpchar, 'a'::bpchar,'postgres'::bpchar,'b'::bpchar,'database'::bpchar);
+select decode('a'::bpchar, 'a'::bpchar,'postgres'::bpchar,'b'::bpchar,'database'::bpchar,'default value'::bpchar);
+select decode('d'::bpchar, 'a'::bpchar,'postgres'::bpchar,'b'::bpchar,'database'::bpchar,'default value'::bpchar);
 
-select decode('a'::bpchar(2), 'a'::bpchar(2),'postgres'::bpchar(15),'b'::bpchar(2),'database'::bpchar(15), 'c'::bpchar(2), 'system'::bpchar(15));
-select decode('d'::bpchar(2), 'a'::bpchar(2),'postgres'::bpchar(15),'b'::bpchar(2),'database'::bpchar(15), 'c'::bpchar(2), 'system'::bpchar(15));
-select decode('a'::bpchar(2), 'a'::bpchar(2),'postgres'::bpchar(15),'b'::bpchar(2),'database'::bpchar(15), 'c'::bpchar(2), 'system'::bpchar(15),'default value'::bpchar(15));
-select decode('d'::bpchar(2), 'a'::bpchar(2),'postgres'::bpchar(15),'b'::bpchar(2),'database'::bpchar(15), 'c'::bpchar(2), 'system'::bpchar(15),'default value'::bpchar(15));
+select decode('a'::bpchar, 'a'::bpchar,'postgres'::bpchar,'b'::bpchar,'database'::bpchar, 'c'::bpchar, 'system'::bpchar);
+select decode('d'::bpchar, 'a'::bpchar,'postgres'::bpchar,'b'::bpchar,'database'::bpchar, 'c'::bpchar, 'system'::bpchar);
+select decode('a'::bpchar, 'a'::bpchar,'postgres'::bpchar,'b'::bpchar,'database'::bpchar, 'c'::bpchar, 'system'::bpchar,'default value'::bpchar);
+select decode('d'::bpchar, 'a'::bpchar,'postgres'::bpchar,'b'::bpchar,'database'::bpchar, 'c'::bpchar, 'system'::bpchar,'default value'::bpchar);
 
-select decode(NULL, 'a'::bpchar(2), 'postgres'::bpchar(15), NULL,'database'::bpchar(15));
-select decode(NULL, 'a'::bpchar(2), 'postgres'::bpchar(15), 'b'::bpchar(2),'database'::bpchar(15));
-select decode(NULL, 'a'::bpchar(2), 'postgres'::bpchar(15), NULL,'database'::bpchar(15),'default value'::bpchar(15));
-select decode(NULL, 'a'::bpchar(2), 'postgres'::bpchar(15), 'b'::bpchar(2),'database'::bpchar(15),'default value'::bpchar(15));
+select decode(NULL, 'a'::bpchar, 'postgres'::bpchar, NULL,'database'::bpchar);
+select decode(NULL, 'a'::bpchar, 'postgres'::bpchar, 'b'::bpchar,'database'::bpchar);
+select decode(NULL, 'a'::bpchar, 'postgres'::bpchar, NULL,'database'::bpchar,'default value'::bpchar);
+select decode(NULL, 'a'::bpchar, 'postgres'::bpchar, 'b'::bpchar,'database'::bpchar,'default value'::bpchar);
 
 -- For type 'bigint'
 select decode(2147483651::bigint, 2147483650::bigint,2147483650::bigint);
@@ -467,114 +467,11 @@ SELECT dump('2008-10-10'::date) ~ E'^Typ=1082 Len=4: \\d+(,\\d+){3}$' AS t;
 SELECT dump('2008-10-10'::timestamp) ~ E'^Typ=1114 Len=8: \\d+(,\\d+){7}$' AS t;
 SELECT dump('2009-10-10'::timestamp) ~ E'^Typ=1114 Len=8: \\d+(,\\d+){7}$' AS t;
 
-select listagg(i::text) from generate_series(1,3) g(i);
-select listagg(i::text, ',') from generate_series(1,3) g(i);
-select coalesce(listagg(i::text), '<NULL>') from (SELECT ''::text) g(i);
-select coalesce(listagg(i::text), '<NULL>') from generate_series(1,0) g(i);
-
--- Tests for package DBMS_RANDOM
-SELECT dbms_random.initialize(8);
-SELECT dbms_random.normal();
-SELECT dbms_random.normal();
-SELECT dbms_random.seed(8);
-SELECT dbms_random.random();
-SELECT dbms_random.seed('test');
-SELECT dbms_random.string('U',5);
-SELECT dbms_random.string('P',2);
-SELECT dbms_random.string('x',4);
-SELECT dbms_random.string('a',2);
-SELECT dbms_random.string('l',3);
-SELECT dbms_random.seed(5);
-SELECT dbms_random.value();
-SELECT dbms_random.value(10,15);
-SELECT dbms_random.terminate();
-
 -- Tests for to_multi_byte
 SELECT to_multi_byte('123$test');
 -- Check internal representation difference
 SELECT octet_length('abc');
 SELECT octet_length(to_multi_byte('abc'));
-
--- Tests for the aggregate median( real | double )
-CREATE FUNCTION checkMedianRealOdd()  RETURNS real AS $$
-DECLARE
- med real;
-
-BEGIN
-	CREATE TABLE median_test (salary real);
-        INSERT INTO median_test VALUES (4500);
-        INSERT INTO median_test VALUES (NULL);
-        INSERT INTO median_test VALUES (2100);
-        INSERT INTO median_test VALUES (3600);
-        INSERT INTO median_test VALUES (4000);
-        SELECT into med median(salary) from median_test;
-        DROP TABLE median_test;
-        return med;
-        
-END;
-$$ LANGUAGE plpgsql;
-
-CREATE FUNCTION checkMedianRealEven() RETURNS real AS $$
-DECLARE
- med real;
-
-BEGIN
-        CREATE TABLE median_test (salary real);
-        INSERT INTO median_test VALUES (4500);
-        INSERT INTO median_test VALUES (1500);
-        INSERT INTO median_test VALUES (2100);
-        INSERT INTO median_test VALUES (3600);
-        INSERT INTO median_test VALUES (1000);
-        INSERT INTO median_test VALUES (4000);
-        select into med median(salary) from median_test;
-        DROP TABLE median_test;
-        return med;
-END;
-$$ LANGUAGE plpgsql;
-
-CREATE FUNCTION checkMedianDoubleOdd() RETURNS double precision AS $$
-DECLARE 
-  med double precision;
-BEGIN
-        CREATE TABLE median_test (salary double precision);
-        INSERT INTO median_test VALUES (4500);
-        INSERT INTO median_test VALUES (1500);
-        INSERT INTO median_test VALUES (2100);
-        INSERT INTO median_test VALUES (3600);
-        INSERT INTO median_test VALUES (4000);
-        select into med median(salary) from median_test;
-        DROP TABLE median_test;
-        return med;
-END;
-$$ LANGUAGE plpgsql;
-
-CREATE FUNCTION checkMedianDoubleEven() RETURNS double precision AS $$
-DECLARE
- med double precision;
-
-BEGIN
-        CREATE TABLE median_test (salary double precision);
-        INSERT INTO median_test VALUES (4500);
-        INSERT INTO median_test VALUES (1500);
-        INSERT INTO median_test VALUES (2100);
-        INSERT INTO median_test VALUES (3600);
-        INSERT INTO median_test VALUES (4000);
-        INSERT INTO median_test VALUES (1000);
-        select into med median(salary) from median_test;
-        DROP TABLE median_test;
-        return med;
-END;
-$$ LANGUAGE plpgsql;
-
-SELECT checkMedianRealOdd();
-SELECT checkMedianRealEven();
-SELECT checkMedianDoubleOdd();
-SELECT checkMedianDoubleEven();
-
-DROP FUNCTION checkMedianRealOdd();
-DROP FUNCTION checkMedianRealEven();
-DROP FUNCTION checkMedianDoubleOdd();
-DROP FUNCTION checkMedianDoubleEven();
 
 -- Tests for round(TIMESTAMP WITH TIME ZONE)
 select round(TIMESTAMP WITH TIME ZONE'12/08/1990 05:35:25','YEAR') = '1991-01-01 00:00:00';
@@ -605,24 +502,3 @@ select to_date('Jan-08-99');
 select to_date('19990108');
 select to_date('990108');
 select to_date('J2451187');
-
--- Tests for nlssort
-DROP DATABASE IF EXISTS db_sort;
-CREATE DATABASE db_sort WITH TEMPLATE = template0 ENCODING='SQL_ASCII' LC_COLLATE='C' LC_CTYPE='C';
-\c db_sort
-CREATE EXTENSION orafce;
-CREATE TABLE test_sort (name TEXT);
-INSERT INTO test_sort VALUES ('red'), ('brown'), ('yellow'), ('Purple');
-SELECT * FROM test_sort ORDER BY NLSSORT(name, 'en_US.utf8');
-SELECT * FROM test_sort ORDER BY NLSSORT(name, '');
-SELECT set_nls_sort('invalid');
-SELECT * FROM test_sort ORDER BY NLSSORT(name);
-SELECT set_nls_sort('');
-SELECT * FROM test_sort ORDER BY NLSSORT(name);
-SELECT set_nls_sort('en_US.utf8');
-SELECT * FROM test_sort ORDER BY NLSSORT(name);
-INSERT INTO test_sort VALUES(NULL);
-SELECT * FROM test_sort ORDER BY NLSSORT(name);
-\c contrib_regression
-DROP DATABASE db_sort;
-


### PR DESCRIPTION
Modify regression tests so that it works on pg versions < 9.2
Regression tests work cleanly till 8.3.
More work is required for 8.2 and 8.1.
