### PR TITLE
Fix build with PostgreSQL 9.4devel

### DIFF
--- a/datefce.c
+++ b/datefce.c
@@ -57,7 +57,11 @@ weekday_search(const WeekDays *weekdays, const char *str, int len)
  * External (defined in PgSQL datetime.c (timestamp utils))
  */
 
+#if PG_VERSION_NUM >= 90400
+extern PGDLLIMPORT const char *const days[];
+#else
 extern PGDLLIMPORT char *days[];
+#endif
 extern PGDLLIMPORT pg_tz *session_timezone;
 
 #define CASE_fmt_YYYY	case 0: case 1: case 2: case 3: case 4: case 5: case 6:

--- a/plvdate.c
+++ b/plvdate.c
@@ -30,7 +30,11 @@
  * External (defined in PgSQL datetime.c (timestamp utils))
  */
 
+#if PG_VERSION_NUM >= 90400
+extern PGDLLIMPORT const char *const days[];
+#else
 extern PGDLLIMPORT char *days[];
+#endif
 
 PG_FUNCTION_INFO_V1(plvdate_add_bizdays);
 PG_FUNCTION_INFO_V1(plvdate_nearest_bizday);


### PR DESCRIPTION
The definition of the variable `days` was changed to include some `const` decoration, which creates a conflict with the previous declaration in orafce.
