### PR TITLE
Rearrange the changes LPAD, RPAD commit and add comments about incompatibilities

### DIFF
--- a/expected/orafce.out
+++ b/expected/orafce.out
@@ -3587,7 +3587,7 @@ SET search_path TO default;
 --
 -- test LPAD family of functions
 --
----- lpad(char, int)
+/* cases where one or more arguments are of type CHAR */
 SELECT '|' || oracle.lpad('あbcd'::char(8), 10) || '|';
    ?column?   
 --------------
@@ -3606,46 +3606,6 @@ SELECT '|' || oracle.lpad('あbcd'::char(8), 1) || '|';
  | |
 (1 row)
 
----- lpad(text, int)
-SELECT '|' || oracle.lpad('あbcd'::text, 10) || '|';
-   ?column?   
---------------
- |     あbcd|
-(1 row)
-
-SELECT '|' || oracle.lpad('あbcd'::text,  5) || '|';
- ?column? 
-----------
- |あbcd|
-(1 row)
-
----- lpad(varchar2, int)
-SELECT '|' || oracle.lpad('あbcd'::varchar2(10), 10) || '|';
-   ?column?   
---------------
- |     あbcd|
-(1 row)
-
-SELECT '|' || oracle.lpad('あbcd'::varchar2(10), 5) || '|';
- ?column? 
-----------
- |あbcd|
-(1 row)
-
----- lpad(nvarchar2, int)
-SELECT '|' || oracle.lpad('あbcd'::nvarchar2(10), 10) || '|';
-   ?column?   
---------------
- |     あbcd|
-(1 row)
-
-SELECT '|' || oracle.lpad('あbcd'::nvarchar2(10), 5) || '|';
- ?column? 
-----------
- |あbcd|
-(1 row)
-
----- lpad(char, int, char)
 SELECT '|' || oracle.lpad('あbcd'::char(5), 10, 'xい'::char(3)) || '|';
    ?column?   
 --------------
@@ -3658,28 +3618,24 @@ SELECT '|' || oracle.lpad('あbcd'::char(5),  5, 'xい'::char(3)) || '|';
  |あbcd|
 (1 row)
 
----- lpad(char, int, text)
 SELECT '|' || oracle.lpad('あbcd'::char(5), 10, 'xい'::text) || '|';
    ?column?   
 --------------
  |xいxあbcd |
 (1 row)
 
----- lpad(char, int, varchar2)
 SELECT '|' || oracle.lpad('あbcd'::char(5), 10, 'xい'::varchar2(5)) || '|';
    ?column?   
 --------------
  |xいxあbcd |
 (1 row)
 
----- lpad(char, int, nvarchar2)
 SELECT '|' || oracle.lpad('あbcd'::char(5), 10, 'xい'::nvarchar2(3)) || '|';
    ?column?   
 --------------
  |xいxあbcd |
 (1 row)
 
----- lpad(text, int, char)
 SELECT '|' || oracle.lpad('あbcd'::text, 10, 'xい'::char(3)) || '|';
    ?column?   
 --------------
@@ -3692,28 +3648,6 @@ SELECT '|' || oracle.lpad('あbcd'::text,  5, 'xい'::char(3)) || '|';
  |あbcd|
 (1 row)
 
----- lpad(text, int, text)
-SELECT '|' || oracle.lpad('あbcd'::text, 10, 'xい'::text) || '|';
-   ?column?   
---------------
- | xいxあbcd|
-(1 row)
-
----- lpad(text, int, varchar2)
-SELECT '|' || oracle.lpad('あbcd'::text, 10, 'xい'::varchar2(5)) || '|';
-   ?column?   
---------------
- | xいxあbcd|
-(1 row)
-
----- lpad(text, int, nvarchar2)
-SELECT '|' || oracle.lpad('あbcd'::text, 10, 'xい'::nvarchar2(3)) || '|';
-   ?column?   
---------------
- | xいxあbcd|
-(1 row)
-
----- lpad(varchar2, int, char)
 SELECT '|' || oracle.lpad('あbcd'::varchar2(5), 10, 'xい'::char(3)) || '|';
    ?column?   
 --------------
@@ -3726,28 +3660,6 @@ SELECT '|' || oracle.lpad('あbcd'::varchar2(5),  5, 'xい'::char(3)) || '|';
  |xあbc|
 (1 row)
 
----- lpad(varchar2, int, text)
-SELECT '|' || oracle.lpad('あbcd'::varchar2(5), 10, 'xい'::text) || '|';
-   ?column?   
---------------
- |xいxいあbc|
-(1 row)
-
----- lpad(varchar2, int, varchar2)
-SELECT '|' || oracle.lpad('あbcd'::varchar2(5), 10, 'xい'::varchar2(5)) || '|';
-   ?column?   
---------------
- |xいxいあbc|
-(1 row)
-
----- lpad(varchar2, int, nvarchar2)
-SELECT '|' || oracle.lpad('あbcd'::varchar2(5), 10, 'xい'::nvarchar2(5)) || '|';
-   ?column?   
---------------
- |xいxいあbc|
-(1 row)
-
----- lpad(nvarchar2, int, char)
 SELECT '|' || oracle.lpad('あbcd'::nvarchar2(5), 10, 'xい'::char(3)) || '|';
    ?column?   
 --------------
@@ -3760,21 +3672,91 @@ SELECT '|' || oracle.lpad('あbcd'::nvarchar2(5),  5, 'xい'::char(3)) || '|';
  |あbcd|
 (1 row)
 
----- lpad(nvarchar2, int, text)
+/* test oracle.lpad(text, int [, text]) */
+SELECT '|' || oracle.lpad('あbcd'::text, 10) || '|';
+   ?column?   
+--------------
+ |     あbcd|
+(1 row)
+
+SELECT '|' || oracle.lpad('あbcd'::text,  5) || '|';
+ ?column? 
+----------
+ |あbcd|
+(1 row)
+
+SELECT '|' || oracle.lpad('あbcd'::varchar2(10), 10) || '|';
+   ?column?   
+--------------
+ |     あbcd|
+(1 row)
+
+SELECT '|' || oracle.lpad('あbcd'::varchar2(10), 5) || '|';
+ ?column? 
+----------
+ |あbcd|
+(1 row)
+
+SELECT '|' || oracle.lpad('あbcd'::nvarchar2(10), 10) || '|';
+   ?column?   
+--------------
+ |     あbcd|
+(1 row)
+
+SELECT '|' || oracle.lpad('あbcd'::nvarchar2(10), 5) || '|';
+ ?column? 
+----------
+ |あbcd|
+(1 row)
+
+SELECT '|' || oracle.lpad('あbcd'::text, 10, 'xい'::text) || '|';
+   ?column?   
+--------------
+ | xいxあbcd|
+(1 row)
+
+SELECT '|' || oracle.lpad('あbcd'::text, 10, 'xい'::varchar2(5)) || '|';
+   ?column?   
+--------------
+ | xいxあbcd|
+(1 row)
+
+SELECT '|' || oracle.lpad('あbcd'::text, 10, 'xい'::nvarchar2(3)) || '|';
+   ?column?   
+--------------
+ | xいxあbcd|
+(1 row)
+
+SELECT '|' || oracle.lpad('あbcd'::varchar2(5), 10, 'xい'::text) || '|';
+   ?column?   
+--------------
+ |xいxいあbc|
+(1 row)
+
+SELECT '|' || oracle.lpad('あbcd'::varchar2(5), 10, 'xい'::varchar2(5)) || '|';
+   ?column?   
+--------------
+ |xいxいあbc|
+(1 row)
+
+SELECT '|' || oracle.lpad('あbcd'::varchar2(5), 10, 'xい'::nvarchar2(5)) || '|';
+   ?column?   
+--------------
+ |xいxいあbc|
+(1 row)
+
 SELECT '|' || oracle.lpad('あbcd'::nvarchar2(5), 10, 'xい'::text) || '|';
    ?column?   
 --------------
  | xいxあbcd|
 (1 row)
 
----- lpad(nvarchar2, int, varchar2)
-SELECT '|' || oracle.lpad('あbcd'::nvarchar2(5), 10, 'xい'::nvarchar2(5)) || '|';
+SELECT '|' || oracle.lpad('あbcd'::nvarchar2(5), 10, 'xい'::varchar2(5)) || '|';
    ?column?   
 --------------
  | xいxあbcd|
 (1 row)
 
----- lpad(nvarchar2, int, nvarchar2)
 SELECT '|' || oracle.lpad('あbcd'::nvarchar2(5), 10, 'xい'::nvarchar2(5)) || '|';
    ?column?   
 --------------
@@ -3784,7 +3766,7 @@ SELECT '|' || oracle.lpad('あbcd'::nvarchar2(5), 10, 'xい'::nvarchar2(5)) || '
 --
 -- test RPAD family of functions
 --
----- rpad(char, int)
+/* cases where one or more arguments are of type CHAR */
 SELECT '|' || oracle.rpad('あbcd'::char(8), 10) || '|';
    ?column?   
 --------------
@@ -3803,46 +3785,6 @@ SELECT '|' || oracle.rpad('あbcd'::char(8), 1) || '|';
  | |
 (1 row)
 
----- rpad(text, int)
-SELECT '|' || oracle.rpad('あbcd'::text, 10) || '|';
-   ?column?   
---------------
- |あbcd     |
-(1 row)
-
-SELECT '|' || oracle.rpad('あbcd'::text,  5) || '|';
- ?column? 
-----------
- |あbcd|
-(1 row)
-
----- rpad(varchar2, int)
-SELECT '|' || oracle.rpad('あbcd'::varchar2(10), 10) || '|';
-   ?column?   
---------------
- |あbcd     |
-(1 row)
-
-SELECT '|' || oracle.rpad('あbcd'::varchar2(10), 5) || '|';
- ?column? 
-----------
- |あbcd|
-(1 row)
-
----- rpad(nvarchar2, int)
-SELECT '|' || oracle.rpad('あbcd'::nvarchar2(10), 10) || '|';
-   ?column?   
---------------
- |あbcd     |
-(1 row)
-
-SELECT '|' || oracle.rpad('あbcd'::nvarchar2(10), 5) || '|';
- ?column? 
-----------
- |あbcd|
-(1 row)
-
----- rpad(char, int, char)
 SELECT '|' || oracle.rpad('あbcd'::char(5), 10, 'xい'::char(3)) || '|';
    ?column?   
 --------------
@@ -3855,28 +3797,24 @@ SELECT '|' || oracle.rpad('あbcd'::char(5),  5, 'xい'::char(3)) || '|';
  |あbcd|
 (1 row)
 
----- rpad(char, int, text)
 SELECT '|' || oracle.rpad('あbcd'::char(5), 10, 'xい'::text) || '|';
    ?column?   
 --------------
  |あbcd xいx|
 (1 row)
 
----- rpad(char, int, varchar2)
 SELECT '|' || oracle.rpad('あbcd'::char(5), 10, 'xい'::varchar2(5)) || '|';
    ?column?   
 --------------
  |あbcd xいx|
 (1 row)
 
----- rpad(char, int, nvarchar2)
 SELECT '|' || oracle.rpad('あbcd'::char(5), 10, 'xい'::nvarchar2(3)) || '|';
    ?column?   
 --------------
  |あbcd xいx|
 (1 row)
 
----- rpad(text, int, char)
 SELECT '|' || oracle.rpad('あbcd'::text, 10, 'xい'::char(3)) || '|';
    ?column?   
 --------------
@@ -3889,28 +3827,6 @@ SELECT '|' || oracle.rpad('あbcd'::text,  5, 'xい'::char(3)) || '|';
  |あbcd|
 (1 row)
 
----- rpad(text, int, text)
-SELECT '|' || oracle.rpad('あbcd'::text, 10, 'xい'::text) || '|';
-   ?column?   
---------------
- | あbcdxいx|
-(1 row)
-
----- rpad(text, int, varchar2)
-SELECT '|' || oracle.rpad('あbcd'::text, 10, 'xい'::varchar2(5)) || '|';
-   ?column?   
---------------
- | あbcdxいx|
-(1 row)
-
----- rpad(text, int, nvarchar2)
-SELECT '|' || oracle.rpad('あbcd'::text, 10, 'xい'::nvarchar2(3)) || '|';
-   ?column?   
---------------
- | あbcdxいx|
-(1 row)
-
----- rpad(varchar2, int, char)
 SELECT '|' || oracle.rpad('あbcd'::varchar2(5), 10, 'xい'::char(3)) || '|';
    ?column?   
 --------------
@@ -3923,28 +3839,6 @@ SELECT '|' || oracle.rpad('あbcd'::varchar2(5),  5, 'xい'::char(3)) || '|';
  |あbcx|
 (1 row)
 
----- rpad(varchar2, int, text)
-SELECT '|' || oracle.rpad('あbcd'::varchar2(5), 10, 'xい'::text) || '|';
-   ?column?   
---------------
- |あbcxいxい|
-(1 row)
-
----- rpad(varchar2, int, varchar2)
-SELECT '|' || oracle.rpad('あbcd'::varchar2(5), 10, 'xい'::varchar2(5)) || '|';
-   ?column?   
---------------
- |あbcxいxい|
-(1 row)
-
----- rpad(varchar2, int, nvarchar2)
-SELECT '|' || oracle.rpad('あbcd'::varchar2(5), 10, 'xい'::nvarchar2(5)) || '|';
-   ?column?   
---------------
- |あbcxいxい|
-(1 row)
-
----- rpad(nvarchar2, int, char)
 SELECT '|' || oracle.rpad('あbcd'::nvarchar2(5), 10, 'xい'::char(3)) || '|';
    ?column?   
 --------------
@@ -3957,21 +3851,91 @@ SELECT '|' || oracle.rpad('あbcd'::nvarchar2(5),  5, 'xい'::char(3)) || '|';
  |あbcd|
 (1 row)
 
----- rpad(nvarchar2, int, text)
+/* test oracle.lpad(text, int [, text]) */
+SELECT '|' || oracle.rpad('あbcd'::text, 10) || '|';
+   ?column?   
+--------------
+ |あbcd     |
+(1 row)
+
+SELECT '|' || oracle.rpad('あbcd'::text,  5) || '|';
+ ?column? 
+----------
+ |あbcd|
+(1 row)
+
+SELECT '|' || oracle.rpad('あbcd'::varchar2(10), 10) || '|';
+   ?column?   
+--------------
+ |あbcd     |
+(1 row)
+
+SELECT '|' || oracle.rpad('あbcd'::varchar2(10), 5) || '|';
+ ?column? 
+----------
+ |あbcd|
+(1 row)
+
+SELECT '|' || oracle.rpad('あbcd'::nvarchar2(10), 10) || '|';
+   ?column?   
+--------------
+ |あbcd     |
+(1 row)
+
+SELECT '|' || oracle.rpad('あbcd'::nvarchar2(10), 5) || '|';
+ ?column? 
+----------
+ |あbcd|
+(1 row)
+
+SELECT '|' || oracle.rpad('あbcd'::text, 10, 'xい'::text) || '|';
+   ?column?   
+--------------
+ | あbcdxいx|
+(1 row)
+
+SELECT '|' || oracle.rpad('あbcd'::text, 10, 'xい'::varchar2(5)) || '|';
+   ?column?   
+--------------
+ | あbcdxいx|
+(1 row)
+
+SELECT '|' || oracle.rpad('あbcd'::text, 10, 'xい'::nvarchar2(3)) || '|';
+   ?column?   
+--------------
+ | あbcdxいx|
+(1 row)
+
+SELECT '|' || oracle.rpad('あbcd'::varchar2(5), 10, 'xい'::text) || '|';
+   ?column?   
+--------------
+ |あbcxいxい|
+(1 row)
+
+SELECT '|' || oracle.rpad('あbcd'::varchar2(5), 10, 'xい'::varchar2(5)) || '|';
+   ?column?   
+--------------
+ |あbcxいxい|
+(1 row)
+
+SELECT '|' || oracle.rpad('あbcd'::varchar2(5), 10, 'xい'::nvarchar2(5)) || '|';
+   ?column?   
+--------------
+ |あbcxいxい|
+(1 row)
+
 SELECT '|' || oracle.rpad('あbcd'::nvarchar2(5), 10, 'xい'::text) || '|';
    ?column?   
 --------------
  | あbcdxいx|
 (1 row)
 
----- rpad(nvarchar2, int, varchar2)
-SELECT '|' || oracle.rpad('あbcd'::nvarchar2(5), 10, 'xい'::nvarchar2(5)) || '|';
+SELECT '|' || oracle.rpad('あbcd'::nvarchar2(5), 10, 'xい'::varchar2(5)) || '|';
    ?column?   
 --------------
  | あbcdxいx|
 (1 row)
 
----- rpad(nvarchar2, int, nvarchar2)
 SELECT '|' || oracle.rpad('あbcd'::nvarchar2(5), 10, 'xい'::nvarchar2(5)) || '|';
    ?column?   
 --------------

--- a/orafce--3.0.13.sql
+++ b/orafce--3.0.13.sql
@@ -2407,140 +2407,150 @@ WHERE proname='nvarchar2';
 /* PAD */
 
 /* LPAD family */
-CREATE FUNCTION oracle.lpad(char,integer,char)
+
+/* Incompatibility #1:
+ *     pg_catalog.lpad removes trailing blanks of CHAR arguments
+ *     because of implicit cast to text
+ *
+ * Incompatibility #2:
+ *     pg_catalog.lpad considers character length, NOT display length
+ *     so, add functions to use custom C implementation of lpad as defined
+ *     in charpad.c
+ */
+CREATE FUNCTION oracle.lpad(char, integer, char)
 RETURNS text
 AS 'MODULE_PATHNAME','lpad'
 LANGUAGE 'c'
 STRICT
 ;
 
-CREATE FUNCTION oracle.lpad(char,integer,text)
+CREATE FUNCTION oracle.lpad(char, integer, text)
 RETURNS text
 AS 'MODULE_PATHNAME','lpad'
 LANGUAGE 'c'
 STRICT
 ;
 
-CREATE FUNCTION oracle.lpad(char,integer,varchar2)
+CREATE FUNCTION oracle.lpad(char, integer, varchar2)
 RETURNS text
 AS 'MODULE_PATHNAME','lpad'
 LANGUAGE 'c'
 STRICT
 ;
 
-CREATE FUNCTION oracle.lpad(char,integer,nvarchar2)
+CREATE FUNCTION oracle.lpad(char, integer, nvarchar2)
 RETURNS text
 AS 'MODULE_PATHNAME','lpad'
 LANGUAGE 'c'
 STRICT
 ;
 
-CREATE FUNCTION oracle.lpad(text,integer,char)
-RETURNS text
-AS 'MODULE_PATHNAME','lpad'
-LANGUAGE 'c'
-STRICT
-;
-
-CREATE FUNCTION oracle.lpad(text,integer,text)
-RETURNS text
-AS 'MODULE_PATHNAME','lpad'
-LANGUAGE 'c'
-STRICT
-;
-
-CREATE FUNCTION oracle.lpad(text,integer,varchar2)
-RETURNS text
-AS 'MODULE_PATHNAME','lpad'
-LANGUAGE 'c'
-STRICT
-;
-
-CREATE FUNCTION oracle.lpad(text,integer,nvarchar2)
-RETURNS text
-AS 'MODULE_PATHNAME','lpad'
-LANGUAGE 'c'
-STRICT
-;
-
-CREATE FUNCTION oracle.lpad(varchar2,integer,char)
-RETURNS text
-AS 'MODULE_PATHNAME','lpad'
-LANGUAGE 'c'
-STRICT
-;
-
-CREATE FUNCTION oracle.lpad(varchar2,integer,text)
-RETURNS text
-AS 'MODULE_PATHNAME','lpad'
-LANGUAGE 'c'
-STRICT
-;
-
-CREATE FUNCTION oracle.lpad(varchar2,integer,varchar2)
-RETURNS text
-AS 'MODULE_PATHNAME','lpad'
-LANGUAGE 'c'
-STRICT
-;
-
-CREATE FUNCTION oracle.lpad(varchar2,integer,nvarchar2)
-RETURNS text
-AS 'MODULE_PATHNAME','lpad'
-LANGUAGE 'c'
-STRICT
-;
-
-CREATE FUNCTION oracle.lpad(nvarchar2,integer,char)
-RETURNS text
-AS 'MODULE_PATHNAME','lpad'
-LANGUAGE 'c'
-STRICT
-;
-
-CREATE FUNCTION oracle.lpad(nvarchar2,integer,text)
-RETURNS text
-AS 'MODULE_PATHNAME','lpad'
-LANGUAGE 'c'
-STRICT
-;
-
-CREATE FUNCTION oracle.lpad(nvarchar2,integer,varchar2)
-RETURNS text
-AS 'MODULE_PATHNAME','lpad'
-LANGUAGE 'c'
-STRICT
-;
-
-CREATE FUNCTION oracle.lpad(nvarchar2,integer,nvarchar2)
-RETURNS text
-AS 'MODULE_PATHNAME','lpad'
-LANGUAGE 'c'
-STRICT
-;
-
-CREATE FUNCTION oracle.lpad(char,integer)
+CREATE FUNCTION oracle.lpad(char, integer)
 RETURNS text
 AS $$ SELECT oracle.lpad($1, $2, ' '::text); $$
 LANGUAGE SQL
 STRICT
 ;
 
-CREATE FUNCTION oracle.lpad(text,integer)
+CREATE FUNCTION oracle.lpad(text, integer, char)
+RETURNS text
+AS 'MODULE_PATHNAME','lpad'
+LANGUAGE 'c'
+STRICT
+;
+
+CREATE FUNCTION oracle.lpad(varchar2, integer, char)
+RETURNS text
+AS 'MODULE_PATHNAME','lpad'
+LANGUAGE 'c'
+STRICT
+;
+
+CREATE FUNCTION oracle.lpad(nvarchar2, integer, char)
+RETURNS text
+AS 'MODULE_PATHNAME','lpad'
+LANGUAGE 'c'
+STRICT
+;
+
+CREATE FUNCTION oracle.lpad(text, integer, text)
+RETURNS text
+AS 'MODULE_PATHNAME','lpad'
+LANGUAGE 'c'
+STRICT
+;
+
+CREATE FUNCTION oracle.lpad(text, integer, varchar2)
+RETURNS text
+AS 'MODULE_PATHNAME','lpad'
+LANGUAGE 'c'
+STRICT
+;
+
+CREATE FUNCTION oracle.lpad(text, integer, nvarchar2)
+RETURNS text
+AS 'MODULE_PATHNAME','lpad'
+LANGUAGE 'c'
+STRICT
+;
+
+CREATE FUNCTION oracle.lpad(text, integer)
 RETURNS text
 AS $$ SELECT oracle.lpad($1, $2, ' '::text); $$
 LANGUAGE SQL
 STRICT
 ;
 
-CREATE FUNCTION oracle.lpad(varchar2,integer)
+CREATE FUNCTION oracle.lpad(varchar2, integer, text)
+RETURNS text
+AS 'MODULE_PATHNAME','lpad'
+LANGUAGE 'c'
+STRICT
+;
+
+CREATE FUNCTION oracle.lpad(varchar2, integer, varchar2)
+RETURNS text
+AS 'MODULE_PATHNAME','lpad'
+LANGUAGE 'c'
+STRICT
+;
+
+CREATE FUNCTION oracle.lpad(varchar2, integer, nvarchar2)
+RETURNS text
+AS 'MODULE_PATHNAME','lpad'
+LANGUAGE 'c'
+STRICT
+;
+
+CREATE FUNCTION oracle.lpad(varchar2, integer)
 RETURNS text
 AS $$ SELECT oracle.lpad($1, $2, ' '::text); $$
 LANGUAGE SQL
 STRICT
 ;
 
-CREATE FUNCTION oracle.lpad(nvarchar2,integer)
+CREATE FUNCTION oracle.lpad(nvarchar2, integer, text)
+RETURNS text
+AS 'MODULE_PATHNAME','lpad'
+LANGUAGE 'c'
+STRICT
+;
+
+CREATE FUNCTION oracle.lpad(nvarchar2, integer, varchar2)
+RETURNS text
+AS 'MODULE_PATHNAME','lpad'
+LANGUAGE 'c'
+STRICT
+;
+
+CREATE FUNCTION oracle.lpad(nvarchar2, integer, nvarchar2)
+RETURNS text
+AS 'MODULE_PATHNAME','lpad'
+LANGUAGE 'c'
+STRICT
+;
+
+CREATE FUNCTION oracle.lpad(nvarchar2, integer)
 RETURNS text
 AS $$ SELECT oracle.lpad($1, $2, ' '::text); $$
 LANGUAGE SQL
@@ -2548,140 +2558,150 @@ STRICT
 ;
 
 /* RPAD family */
-CREATE FUNCTION oracle.rpad(char,integer,char)
+
+/* Incompatibility #1:
+ *     pg_catalog.rpad removes trailing blanks of CHAR arguments
+ *     because of implicit cast to text
+ *
+ * Incompatibility #2:
+ *     pg_catalog.rpad considers character length, NOT display length
+ *     so, add functions to use custom C implementation of rpad as defined
+ *     in charpad.c
+ */
+CREATE FUNCTION oracle.rpad(char, integer, char)
 RETURNS text
 AS 'MODULE_PATHNAME','rpad'
 LANGUAGE 'c'
 STRICT
 ;
 
-CREATE FUNCTION oracle.rpad(char,integer,text)
+CREATE FUNCTION oracle.rpad(char, integer, text)
 RETURNS text
 AS 'MODULE_PATHNAME','rpad'
 LANGUAGE 'c'
 STRICT
 ;
 
-CREATE FUNCTION oracle.rpad(char,integer,varchar2)
+CREATE FUNCTION oracle.rpad(char, integer, varchar2)
 RETURNS text
 AS 'MODULE_PATHNAME','rpad'
 LANGUAGE 'c'
 STRICT
 ;
 
-CREATE FUNCTION oracle.rpad(char,integer,nvarchar2)
+CREATE FUNCTION oracle.rpad(char, integer, nvarchar2)
 RETURNS text
 AS 'MODULE_PATHNAME','rpad'
 LANGUAGE 'c'
 STRICT
 ;
 
-CREATE FUNCTION oracle.rpad(text,integer,char)
-RETURNS text
-AS 'MODULE_PATHNAME','rpad'
-LANGUAGE 'c'
-STRICT
-;
-
-CREATE FUNCTION oracle.rpad(text,integer,text)
-RETURNS text
-AS 'MODULE_PATHNAME','rpad'
-LANGUAGE 'c'
-STRICT
-;
-
-CREATE FUNCTION oracle.rpad(text,integer,varchar2)
-RETURNS text
-AS 'MODULE_PATHNAME','rpad'
-LANGUAGE 'c'
-STRICT
-;
-
-CREATE FUNCTION oracle.rpad(text,integer,nvarchar2)
-RETURNS text
-AS 'MODULE_PATHNAME','rpad'
-LANGUAGE 'c'
-STRICT
-;
-
-CREATE FUNCTION oracle.rpad(varchar2,integer,char)
-RETURNS text
-AS 'MODULE_PATHNAME','rpad'
-LANGUAGE 'c'
-STRICT
-;
-
-CREATE FUNCTION oracle.rpad(varchar2,integer,text)
-RETURNS text
-AS 'MODULE_PATHNAME','rpad'
-LANGUAGE 'c'
-STRICT
-;
-
-CREATE FUNCTION oracle.rpad(varchar2,integer,varchar2)
-RETURNS text
-AS 'MODULE_PATHNAME','rpad'
-LANGUAGE 'c'
-STRICT
-;
-
-CREATE FUNCTION oracle.rpad(varchar2,integer,nvarchar2)
-RETURNS text
-AS 'MODULE_PATHNAME','rpad'
-LANGUAGE 'c'
-STRICT
-;
-
-CREATE FUNCTION oracle.rpad(nvarchar2,integer,char)
-RETURNS text
-AS 'MODULE_PATHNAME','rpad'
-LANGUAGE 'c'
-STRICT
-;
-
-CREATE FUNCTION oracle.rpad(nvarchar2,integer,text)
-RETURNS text
-AS 'MODULE_PATHNAME','rpad'
-LANGUAGE 'c'
-STRICT
-;
-
-CREATE FUNCTION oracle.rpad(nvarchar2,integer,varchar2)
-RETURNS text
-AS 'MODULE_PATHNAME','rpad'
-LANGUAGE 'c'
-STRICT
-;
-
-CREATE FUNCTION oracle.rpad(nvarchar2,integer,nvarchar2)
-RETURNS text
-AS 'MODULE_PATHNAME','rpad'
-LANGUAGE 'c'
-STRICT
-;
-
-CREATE FUNCTION oracle.rpad(char,integer)
+CREATE FUNCTION oracle.rpad(char, integer)
 RETURNS text
 AS $$ SELECT oracle.rpad($1, $2, ' '::text); $$
 LANGUAGE SQL
 STRICT
 ;
 
-CREATE FUNCTION oracle.rpad(text,integer)
+CREATE FUNCTION oracle.rpad(text, integer, char)
+RETURNS text
+AS 'MODULE_PATHNAME','rpad'
+LANGUAGE 'c'
+STRICT
+;
+
+CREATE FUNCTION oracle.rpad(varchar2, integer, char)
+RETURNS text
+AS 'MODULE_PATHNAME','rpad'
+LANGUAGE 'c'
+STRICT
+;
+
+CREATE FUNCTION oracle.rpad(nvarchar2, integer, char)
+RETURNS text
+AS 'MODULE_PATHNAME','rpad'
+LANGUAGE 'c'
+STRICT
+;
+
+CREATE FUNCTION oracle.rpad(text, integer, text)
+RETURNS text
+AS 'MODULE_PATHNAME','rpad'
+LANGUAGE 'c'
+STRICT
+;
+
+CREATE FUNCTION oracle.rpad(text, integer, varchar2)
+RETURNS text
+AS 'MODULE_PATHNAME','rpad'
+LANGUAGE 'c'
+STRICT
+;
+
+CREATE FUNCTION oracle.rpad(text, integer, nvarchar2)
+RETURNS text
+AS 'MODULE_PATHNAME','rpad'
+LANGUAGE 'c'
+STRICT
+;
+
+CREATE FUNCTION oracle.rpad(text, integer)
 RETURNS text
 AS $$ SELECT oracle.rpad($1, $2, ' '::text); $$
 LANGUAGE SQL
 STRICT
 ;
 
-CREATE FUNCTION oracle.rpad(varchar2,integer)
+CREATE FUNCTION oracle.rpad(varchar2, integer, text)
+RETURNS text
+AS 'MODULE_PATHNAME','rpad'
+LANGUAGE 'c'
+STRICT
+;
+
+CREATE FUNCTION oracle.rpad(varchar2, integer, varchar2)
+RETURNS text
+AS 'MODULE_PATHNAME','rpad'
+LANGUAGE 'c'
+STRICT
+;
+
+CREATE FUNCTION oracle.rpad(varchar2, integer, nvarchar2)
+RETURNS text
+AS 'MODULE_PATHNAME','rpad'
+LANGUAGE 'c'
+STRICT
+;
+
+CREATE FUNCTION oracle.rpad(varchar2, integer)
 RETURNS text
 AS $$ SELECT oracle.rpad($1, $2, ' '::text); $$
 LANGUAGE SQL
 STRICT
 ;
 
-CREATE FUNCTION oracle.rpad(nvarchar2,integer)
+CREATE FUNCTION oracle.rpad(nvarchar2, integer, text)
+RETURNS text
+AS 'MODULE_PATHNAME','rpad'
+LANGUAGE 'c'
+STRICT
+;
+
+CREATE FUNCTION oracle.rpad(nvarchar2, integer, varchar2)
+RETURNS text
+AS 'MODULE_PATHNAME','rpad'
+LANGUAGE 'c'
+STRICT
+;
+
+CREATE FUNCTION oracle.rpad(nvarchar2, integer, nvarchar2)
+RETURNS text
+AS 'MODULE_PATHNAME','rpad'
+LANGUAGE 'c'
+STRICT
+;
+
+CREATE FUNCTION oracle.rpad(nvarchar2, integer)
 RETURNS text
 AS $$ SELECT oracle.rpad($1, $2, ' '::text); $$
 LANGUAGE SQL

--- a/orafce-common.sql
+++ b/orafce-common.sql
@@ -2103,140 +2103,150 @@ typmod_out = nvarchar2typmodout
 /* PAD */
 
 /* LPAD family */
-CREATE FUNCTION oracle.lpad(char,integer,char)
+
+/* Incompatibility #1:
+ *     pg_catalog.lpad removes trailing blanks of CHAR arguments
+ *     because of implicit cast to text
+ *
+ * Incompatibility #2:
+ *     pg_catalog.lpad considers character length, NOT display length
+ *     so, add functions to use custom C implementation of lpad as defined
+ *     in charpad.c
+ */
+CREATE FUNCTION oracle.lpad(char, integer, char)
 RETURNS text
 AS 'MODULE_PATHNAME','lpad'
 LANGUAGE 'c'
 STRICT
 ;
 
-CREATE FUNCTION oracle.lpad(char,integer,text)
+CREATE FUNCTION oracle.lpad(char, integer, text)
 RETURNS text
 AS 'MODULE_PATHNAME','lpad'
 LANGUAGE 'c'
 STRICT
 ;
 
-CREATE FUNCTION oracle.lpad(char,integer,varchar2)
+CREATE FUNCTION oracle.lpad(char, integer, varchar2)
 RETURNS text
 AS 'MODULE_PATHNAME','lpad'
 LANGUAGE 'c'
 STRICT
 ;
 
-CREATE FUNCTION oracle.lpad(char,integer,nvarchar2)
+CREATE FUNCTION oracle.lpad(char, integer, nvarchar2)
 RETURNS text
 AS 'MODULE_PATHNAME','lpad'
 LANGUAGE 'c'
 STRICT
 ;
 
-CREATE FUNCTION oracle.lpad(text,integer,char)
-RETURNS text
-AS 'MODULE_PATHNAME','lpad'
-LANGUAGE 'c'
-STRICT
-;
-
-CREATE FUNCTION oracle.lpad(text,integer,text)
-RETURNS text
-AS 'MODULE_PATHNAME','lpad'
-LANGUAGE 'c'
-STRICT
-;
-
-CREATE FUNCTION oracle.lpad(text,integer,varchar2)
-RETURNS text
-AS 'MODULE_PATHNAME','lpad'
-LANGUAGE 'c'
-STRICT
-;
-
-CREATE FUNCTION oracle.lpad(text,integer,nvarchar2)
-RETURNS text
-AS 'MODULE_PATHNAME','lpad'
-LANGUAGE 'c'
-STRICT
-;
-
-CREATE FUNCTION oracle.lpad(varchar2,integer,char)
-RETURNS text
-AS 'MODULE_PATHNAME','lpad'
-LANGUAGE 'c'
-STRICT
-;
-
-CREATE FUNCTION oracle.lpad(varchar2,integer,text)
-RETURNS text
-AS 'MODULE_PATHNAME','lpad'
-LANGUAGE 'c'
-STRICT
-;
-
-CREATE FUNCTION oracle.lpad(varchar2,integer,varchar2)
-RETURNS text
-AS 'MODULE_PATHNAME','lpad'
-LANGUAGE 'c'
-STRICT
-;
-
-CREATE FUNCTION oracle.lpad(varchar2,integer,nvarchar2)
-RETURNS text
-AS 'MODULE_PATHNAME','lpad'
-LANGUAGE 'c'
-STRICT
-;
-
-CREATE FUNCTION oracle.lpad(nvarchar2,integer,char)
-RETURNS text
-AS 'MODULE_PATHNAME','lpad'
-LANGUAGE 'c'
-STRICT
-;
-
-CREATE FUNCTION oracle.lpad(nvarchar2,integer,text)
-RETURNS text
-AS 'MODULE_PATHNAME','lpad'
-LANGUAGE 'c'
-STRICT
-;
-
-CREATE FUNCTION oracle.lpad(nvarchar2,integer,varchar2)
-RETURNS text
-AS 'MODULE_PATHNAME','lpad'
-LANGUAGE 'c'
-STRICT
-;
-
-CREATE FUNCTION oracle.lpad(nvarchar2,integer,nvarchar2)
-RETURNS text
-AS 'MODULE_PATHNAME','lpad'
-LANGUAGE 'c'
-STRICT
-;
-
-CREATE FUNCTION oracle.lpad(char,integer)
+CREATE FUNCTION oracle.lpad(char, integer)
 RETURNS text
 AS $$ SELECT oracle.lpad($1, $2, ' '::text); $$
 LANGUAGE SQL
 STRICT
 ;
 
-CREATE FUNCTION oracle.lpad(text,integer)
+CREATE FUNCTION oracle.lpad(text, integer, char)
+RETURNS text
+AS 'MODULE_PATHNAME','lpad'
+LANGUAGE 'c'
+STRICT
+;
+
+CREATE FUNCTION oracle.lpad(varchar2, integer, char)
+RETURNS text
+AS 'MODULE_PATHNAME','lpad'
+LANGUAGE 'c'
+STRICT
+;
+
+CREATE FUNCTION oracle.lpad(nvarchar2, integer, char)
+RETURNS text
+AS 'MODULE_PATHNAME','lpad'
+LANGUAGE 'c'
+STRICT
+;
+
+CREATE FUNCTION oracle.lpad(text, integer, text)
+RETURNS text
+AS 'MODULE_PATHNAME','lpad'
+LANGUAGE 'c'
+STRICT
+;
+
+CREATE FUNCTION oracle.lpad(text, integer, varchar2)
+RETURNS text
+AS 'MODULE_PATHNAME','lpad'
+LANGUAGE 'c'
+STRICT
+;
+
+CREATE FUNCTION oracle.lpad(text, integer, nvarchar2)
+RETURNS text
+AS 'MODULE_PATHNAME','lpad'
+LANGUAGE 'c'
+STRICT
+;
+
+CREATE FUNCTION oracle.lpad(text, integer)
 RETURNS text
 AS $$ SELECT oracle.lpad($1, $2, ' '::text); $$
 LANGUAGE SQL
 STRICT
 ;
 
-CREATE FUNCTION oracle.lpad(varchar2,integer)
+CREATE FUNCTION oracle.lpad(varchar2, integer, text)
+RETURNS text
+AS 'MODULE_PATHNAME','lpad'
+LANGUAGE 'c'
+STRICT
+;
+
+CREATE FUNCTION oracle.lpad(varchar2, integer, varchar2)
+RETURNS text
+AS 'MODULE_PATHNAME','lpad'
+LANGUAGE 'c'
+STRICT
+;
+
+CREATE FUNCTION oracle.lpad(varchar2, integer, nvarchar2)
+RETURNS text
+AS 'MODULE_PATHNAME','lpad'
+LANGUAGE 'c'
+STRICT
+;
+
+CREATE FUNCTION oracle.lpad(varchar2, integer)
 RETURNS text
 AS $$ SELECT oracle.lpad($1, $2, ' '::text); $$
 LANGUAGE SQL
 STRICT
 ;
 
-CREATE FUNCTION oracle.lpad(nvarchar2,integer)
+CREATE FUNCTION oracle.lpad(nvarchar2, integer, text)
+RETURNS text
+AS 'MODULE_PATHNAME','lpad'
+LANGUAGE 'c'
+STRICT
+;
+
+CREATE FUNCTION oracle.lpad(nvarchar2, integer, varchar2)
+RETURNS text
+AS 'MODULE_PATHNAME','lpad'
+LANGUAGE 'c'
+STRICT
+;
+
+CREATE FUNCTION oracle.lpad(nvarchar2, integer, nvarchar2)
+RETURNS text
+AS 'MODULE_PATHNAME','lpad'
+LANGUAGE 'c'
+STRICT
+;
+
+CREATE FUNCTION oracle.lpad(nvarchar2, integer)
 RETURNS text
 AS $$ SELECT oracle.lpad($1, $2, ' '::text); $$
 LANGUAGE SQL
@@ -2244,140 +2254,150 @@ STRICT
 ;
 
 /* RPAD family */
-CREATE FUNCTION oracle.rpad(char,integer,char)
+
+/* Incompatibility #1:
+ *     pg_catalog.rpad removes trailing blanks of CHAR arguments
+ *     because of implicit cast to text
+ *
+ * Incompatibility #2:
+ *     pg_catalog.rpad considers character length, NOT display length
+ *     so, add functions to use custom C implementation of rpad as defined
+ *     in charpad.c
+ */
+CREATE FUNCTION oracle.rpad(char, integer, char)
 RETURNS text
 AS 'MODULE_PATHNAME','rpad'
 LANGUAGE 'c'
 STRICT
 ;
 
-CREATE FUNCTION oracle.rpad(char,integer,text)
+CREATE FUNCTION oracle.rpad(char, integer, text)
 RETURNS text
 AS 'MODULE_PATHNAME','rpad'
 LANGUAGE 'c'
 STRICT
 ;
 
-CREATE FUNCTION oracle.rpad(char,integer,varchar2)
+CREATE FUNCTION oracle.rpad(char, integer, varchar2)
 RETURNS text
 AS 'MODULE_PATHNAME','rpad'
 LANGUAGE 'c'
 STRICT
 ;
 
-CREATE FUNCTION oracle.rpad(char,integer,nvarchar2)
+CREATE FUNCTION oracle.rpad(char, integer, nvarchar2)
 RETURNS text
 AS 'MODULE_PATHNAME','rpad'
 LANGUAGE 'c'
 STRICT
 ;
 
-CREATE FUNCTION oracle.rpad(text,integer,char)
-RETURNS text
-AS 'MODULE_PATHNAME','rpad'
-LANGUAGE 'c'
-STRICT
-;
-
-CREATE FUNCTION oracle.rpad(text,integer,text)
-RETURNS text
-AS 'MODULE_PATHNAME','rpad'
-LANGUAGE 'c'
-STRICT
-;
-
-CREATE FUNCTION oracle.rpad(text,integer,varchar2)
-RETURNS text
-AS 'MODULE_PATHNAME','rpad'
-LANGUAGE 'c'
-STRICT
-;
-
-CREATE FUNCTION oracle.rpad(text,integer,nvarchar2)
-RETURNS text
-AS 'MODULE_PATHNAME','rpad'
-LANGUAGE 'c'
-STRICT
-;
-
-CREATE FUNCTION oracle.rpad(varchar2,integer,char)
-RETURNS text
-AS 'MODULE_PATHNAME','rpad'
-LANGUAGE 'c'
-STRICT
-;
-
-CREATE FUNCTION oracle.rpad(varchar2,integer,text)
-RETURNS text
-AS 'MODULE_PATHNAME','rpad'
-LANGUAGE 'c'
-STRICT
-;
-
-CREATE FUNCTION oracle.rpad(varchar2,integer,varchar2)
-RETURNS text
-AS 'MODULE_PATHNAME','rpad'
-LANGUAGE 'c'
-STRICT
-;
-
-CREATE FUNCTION oracle.rpad(varchar2,integer,nvarchar2)
-RETURNS text
-AS 'MODULE_PATHNAME','rpad'
-LANGUAGE 'c'
-STRICT
-;
-
-CREATE FUNCTION oracle.rpad(nvarchar2,integer,char)
-RETURNS text
-AS 'MODULE_PATHNAME','rpad'
-LANGUAGE 'c'
-STRICT
-;
-
-CREATE FUNCTION oracle.rpad(nvarchar2,integer,text)
-RETURNS text
-AS 'MODULE_PATHNAME','rpad'
-LANGUAGE 'c'
-STRICT
-;
-
-CREATE FUNCTION oracle.rpad(nvarchar2,integer,varchar2)
-RETURNS text
-AS 'MODULE_PATHNAME','rpad'
-LANGUAGE 'c'
-STRICT
-;
-
-CREATE FUNCTION oracle.rpad(nvarchar2,integer,nvarchar2)
-RETURNS text
-AS 'MODULE_PATHNAME','rpad'
-LANGUAGE 'c'
-STRICT
-;
-
-CREATE FUNCTION oracle.rpad(char,integer)
+CREATE FUNCTION oracle.rpad(char, integer)
 RETURNS text
 AS $$ SELECT oracle.rpad($1, $2, ' '::text); $$
 LANGUAGE SQL
 STRICT
 ;
 
-CREATE FUNCTION oracle.rpad(text,integer)
+CREATE FUNCTION oracle.rpad(text, integer, char)
+RETURNS text
+AS 'MODULE_PATHNAME','rpad'
+LANGUAGE 'c'
+STRICT
+;
+
+CREATE FUNCTION oracle.rpad(varchar2, integer, char)
+RETURNS text
+AS 'MODULE_PATHNAME','rpad'
+LANGUAGE 'c'
+STRICT
+;
+
+CREATE FUNCTION oracle.rpad(nvarchar2, integer, char)
+RETURNS text
+AS 'MODULE_PATHNAME','rpad'
+LANGUAGE 'c'
+STRICT
+;
+
+CREATE FUNCTION oracle.rpad(text, integer, text)
+RETURNS text
+AS 'MODULE_PATHNAME','rpad'
+LANGUAGE 'c'
+STRICT
+;
+
+CREATE FUNCTION oracle.rpad(text, integer, varchar2)
+RETURNS text
+AS 'MODULE_PATHNAME','rpad'
+LANGUAGE 'c'
+STRICT
+;
+
+CREATE FUNCTION oracle.rpad(text, integer, nvarchar2)
+RETURNS text
+AS 'MODULE_PATHNAME','rpad'
+LANGUAGE 'c'
+STRICT
+;
+
+CREATE FUNCTION oracle.rpad(text, integer)
 RETURNS text
 AS $$ SELECT oracle.rpad($1, $2, ' '::text); $$
 LANGUAGE SQL
 STRICT
 ;
 
-CREATE FUNCTION oracle.rpad(varchar2,integer)
+CREATE FUNCTION oracle.rpad(varchar2, integer, text)
+RETURNS text
+AS 'MODULE_PATHNAME','rpad'
+LANGUAGE 'c'
+STRICT
+;
+
+CREATE FUNCTION oracle.rpad(varchar2, integer, varchar2)
+RETURNS text
+AS 'MODULE_PATHNAME','rpad'
+LANGUAGE 'c'
+STRICT
+;
+
+CREATE FUNCTION oracle.rpad(varchar2, integer, nvarchar2)
+RETURNS text
+AS 'MODULE_PATHNAME','rpad'
+LANGUAGE 'c'
+STRICT
+;
+
+CREATE FUNCTION oracle.rpad(varchar2, integer)
 RETURNS text
 AS $$ SELECT oracle.rpad($1, $2, ' '::text); $$
 LANGUAGE SQL
 STRICT
 ;
 
-CREATE FUNCTION oracle.rpad(nvarchar2,integer)
+CREATE FUNCTION oracle.rpad(nvarchar2, integer, text)
+RETURNS text
+AS 'MODULE_PATHNAME','rpad'
+LANGUAGE 'c'
+STRICT
+;
+
+CREATE FUNCTION oracle.rpad(nvarchar2, integer, varchar2)
+RETURNS text
+AS 'MODULE_PATHNAME','rpad'
+LANGUAGE 'c'
+STRICT
+;
+
+CREATE FUNCTION oracle.rpad(nvarchar2, integer, nvarchar2)
+RETURNS text
+AS 'MODULE_PATHNAME','rpad'
+LANGUAGE 'c'
+STRICT
+;
+
+CREATE FUNCTION oracle.rpad(nvarchar2, integer)
 RETURNS text
 AS $$ SELECT oracle.rpad($1, $2, ' '::text); $$
 LANGUAGE SQL

--- a/sql/orafce.sql
+++ b/sql/orafce.sql
@@ -789,144 +789,92 @@ SET search_path TO default;
 -- test LPAD family of functions
 --
 
----- lpad(char, int)
+/* cases where one or more arguments are of type CHAR */
 SELECT '|' || oracle.lpad('あbcd'::char(8), 10) || '|';
 SELECT '|' || oracle.lpad('あbcd'::char(8),  5) || '|';
 SELECT '|' || oracle.lpad('あbcd'::char(8), 1) || '|';
 
----- lpad(text, int)
-SELECT '|' || oracle.lpad('あbcd'::text, 10) || '|';
-SELECT '|' || oracle.lpad('あbcd'::text,  5) || '|';
-
----- lpad(varchar2, int)
-SELECT '|' || oracle.lpad('あbcd'::varchar2(10), 10) || '|';
-SELECT '|' || oracle.lpad('あbcd'::varchar2(10), 5) || '|';
-
----- lpad(nvarchar2, int)
-SELECT '|' || oracle.lpad('あbcd'::nvarchar2(10), 10) || '|';
-SELECT '|' || oracle.lpad('あbcd'::nvarchar2(10), 5) || '|';
-
----- lpad(char, int, char)
 SELECT '|' || oracle.lpad('あbcd'::char(5), 10, 'xい'::char(3)) || '|';
 SELECT '|' || oracle.lpad('あbcd'::char(5),  5, 'xい'::char(3)) || '|';
 
----- lpad(char, int, text)
 SELECT '|' || oracle.lpad('あbcd'::char(5), 10, 'xい'::text) || '|';
-
----- lpad(char, int, varchar2)
 SELECT '|' || oracle.lpad('あbcd'::char(5), 10, 'xい'::varchar2(5)) || '|';
-
----- lpad(char, int, nvarchar2)
 SELECT '|' || oracle.lpad('あbcd'::char(5), 10, 'xい'::nvarchar2(3)) || '|';
 
----- lpad(text, int, char)
 SELECT '|' || oracle.lpad('あbcd'::text, 10, 'xい'::char(3)) || '|';
 SELECT '|' || oracle.lpad('あbcd'::text,  5, 'xい'::char(3)) || '|';
 
----- lpad(text, int, text)
-SELECT '|' || oracle.lpad('あbcd'::text, 10, 'xい'::text) || '|';
-
----- lpad(text, int, varchar2)
-SELECT '|' || oracle.lpad('あbcd'::text, 10, 'xい'::varchar2(5)) || '|';
-
----- lpad(text, int, nvarchar2)
-SELECT '|' || oracle.lpad('あbcd'::text, 10, 'xい'::nvarchar2(3)) || '|';
-
----- lpad(varchar2, int, char)
 SELECT '|' || oracle.lpad('あbcd'::varchar2(5), 10, 'xい'::char(3)) || '|';
 SELECT '|' || oracle.lpad('あbcd'::varchar2(5),  5, 'xい'::char(3)) || '|';
 
----- lpad(varchar2, int, text)
-SELECT '|' || oracle.lpad('あbcd'::varchar2(5), 10, 'xい'::text) || '|';
-
----- lpad(varchar2, int, varchar2)
-SELECT '|' || oracle.lpad('あbcd'::varchar2(5), 10, 'xい'::varchar2(5)) || '|';
-
----- lpad(varchar2, int, nvarchar2)
-SELECT '|' || oracle.lpad('あbcd'::varchar2(5), 10, 'xい'::nvarchar2(5)) || '|';
-
----- lpad(nvarchar2, int, char)
 SELECT '|' || oracle.lpad('あbcd'::nvarchar2(5), 10, 'xい'::char(3)) || '|';
 SELECT '|' || oracle.lpad('あbcd'::nvarchar2(5),  5, 'xい'::char(3)) || '|';
 
----- lpad(nvarchar2, int, text)
+/* test oracle.lpad(text, int [, text]) */
+SELECT '|' || oracle.lpad('あbcd'::text, 10) || '|';
+SELECT '|' || oracle.lpad('あbcd'::text,  5) || '|';
+
+SELECT '|' || oracle.lpad('あbcd'::varchar2(10), 10) || '|';
+SELECT '|' || oracle.lpad('あbcd'::varchar2(10), 5) || '|';
+
+SELECT '|' || oracle.lpad('あbcd'::nvarchar2(10), 10) || '|';
+SELECT '|' || oracle.lpad('あbcd'::nvarchar2(10), 5) || '|';
+
+SELECT '|' || oracle.lpad('あbcd'::text, 10, 'xい'::text) || '|';
+SELECT '|' || oracle.lpad('あbcd'::text, 10, 'xい'::varchar2(5)) || '|';
+SELECT '|' || oracle.lpad('あbcd'::text, 10, 'xい'::nvarchar2(3)) || '|';
+
+SELECT '|' || oracle.lpad('あbcd'::varchar2(5), 10, 'xい'::text) || '|';
+SELECT '|' || oracle.lpad('あbcd'::varchar2(5), 10, 'xい'::varchar2(5)) || '|';
+SELECT '|' || oracle.lpad('あbcd'::varchar2(5), 10, 'xい'::nvarchar2(5)) || '|';
+
 SELECT '|' || oracle.lpad('あbcd'::nvarchar2(5), 10, 'xい'::text) || '|';
-
----- lpad(nvarchar2, int, varchar2)
-SELECT '|' || oracle.lpad('あbcd'::nvarchar2(5), 10, 'xい'::nvarchar2(5)) || '|';
-
----- lpad(nvarchar2, int, nvarchar2)
+SELECT '|' || oracle.lpad('あbcd'::nvarchar2(5), 10, 'xい'::varchar2(5)) || '|';
 SELECT '|' || oracle.lpad('あbcd'::nvarchar2(5), 10, 'xい'::nvarchar2(5)) || '|';
 
 --
 -- test RPAD family of functions
 --
 
----- rpad(char, int)
+/* cases where one or more arguments are of type CHAR */
 SELECT '|' || oracle.rpad('あbcd'::char(8), 10) || '|';
 SELECT '|' || oracle.rpad('あbcd'::char(8),  5) || '|';
 SELECT '|' || oracle.rpad('あbcd'::char(8), 1) || '|';
 
----- rpad(text, int)
-SELECT '|' || oracle.rpad('あbcd'::text, 10) || '|';
-SELECT '|' || oracle.rpad('あbcd'::text,  5) || '|';
-
----- rpad(varchar2, int)
-SELECT '|' || oracle.rpad('あbcd'::varchar2(10), 10) || '|';
-SELECT '|' || oracle.rpad('あbcd'::varchar2(10), 5) || '|';
-
----- rpad(nvarchar2, int)
-SELECT '|' || oracle.rpad('あbcd'::nvarchar2(10), 10) || '|';
-SELECT '|' || oracle.rpad('あbcd'::nvarchar2(10), 5) || '|';
-
----- rpad(char, int, char)
 SELECT '|' || oracle.rpad('あbcd'::char(5), 10, 'xい'::char(3)) || '|';
 SELECT '|' || oracle.rpad('あbcd'::char(5),  5, 'xい'::char(3)) || '|';
 
----- rpad(char, int, text)
 SELECT '|' || oracle.rpad('あbcd'::char(5), 10, 'xい'::text) || '|';
-
----- rpad(char, int, varchar2)
 SELECT '|' || oracle.rpad('あbcd'::char(5), 10, 'xい'::varchar2(5)) || '|';
-
----- rpad(char, int, nvarchar2)
 SELECT '|' || oracle.rpad('あbcd'::char(5), 10, 'xい'::nvarchar2(3)) || '|';
 
----- rpad(text, int, char)
 SELECT '|' || oracle.rpad('あbcd'::text, 10, 'xい'::char(3)) || '|';
 SELECT '|' || oracle.rpad('あbcd'::text,  5, 'xい'::char(3)) || '|';
 
----- rpad(text, int, text)
-SELECT '|' || oracle.rpad('あbcd'::text, 10, 'xい'::text) || '|';
-
----- rpad(text, int, varchar2)
-SELECT '|' || oracle.rpad('あbcd'::text, 10, 'xい'::varchar2(5)) || '|';
-
----- rpad(text, int, nvarchar2)
-SELECT '|' || oracle.rpad('あbcd'::text, 10, 'xい'::nvarchar2(3)) || '|';
-
----- rpad(varchar2, int, char)
 SELECT '|' || oracle.rpad('あbcd'::varchar2(5), 10, 'xい'::char(3)) || '|';
 SELECT '|' || oracle.rpad('あbcd'::varchar2(5),  5, 'xい'::char(3)) || '|';
 
----- rpad(varchar2, int, text)
-SELECT '|' || oracle.rpad('あbcd'::varchar2(5), 10, 'xい'::text) || '|';
-
----- rpad(varchar2, int, varchar2)
-SELECT '|' || oracle.rpad('あbcd'::varchar2(5), 10, 'xい'::varchar2(5)) || '|';
-
----- rpad(varchar2, int, nvarchar2)
-SELECT '|' || oracle.rpad('あbcd'::varchar2(5), 10, 'xい'::nvarchar2(5)) || '|';
-
----- rpad(nvarchar2, int, char)
 SELECT '|' || oracle.rpad('あbcd'::nvarchar2(5), 10, 'xい'::char(3)) || '|';
 SELECT '|' || oracle.rpad('あbcd'::nvarchar2(5),  5, 'xい'::char(3)) || '|';
 
----- rpad(nvarchar2, int, text)
+/* test oracle.lpad(text, int [, text]) */
+SELECT '|' || oracle.rpad('あbcd'::text, 10) || '|';
+SELECT '|' || oracle.rpad('あbcd'::text,  5) || '|';
+
+SELECT '|' || oracle.rpad('あbcd'::varchar2(10), 10) || '|';
+SELECT '|' || oracle.rpad('あbcd'::varchar2(10), 5) || '|';
+
+SELECT '|' || oracle.rpad('あbcd'::nvarchar2(10), 10) || '|';
+SELECT '|' || oracle.rpad('あbcd'::nvarchar2(10), 5) || '|';
+
+SELECT '|' || oracle.rpad('あbcd'::text, 10, 'xい'::text) || '|';
+SELECT '|' || oracle.rpad('あbcd'::text, 10, 'xい'::varchar2(5)) || '|';
+SELECT '|' || oracle.rpad('あbcd'::text, 10, 'xい'::nvarchar2(3)) || '|';
+
+SELECT '|' || oracle.rpad('あbcd'::varchar2(5), 10, 'xい'::text) || '|';
+SELECT '|' || oracle.rpad('あbcd'::varchar2(5), 10, 'xい'::varchar2(5)) || '|';
+SELECT '|' || oracle.rpad('あbcd'::varchar2(5), 10, 'xい'::nvarchar2(5)) || '|';
+
 SELECT '|' || oracle.rpad('あbcd'::nvarchar2(5), 10, 'xい'::text) || '|';
-
----- rpad(nvarchar2, int, varchar2)
-SELECT '|' || oracle.rpad('あbcd'::nvarchar2(5), 10, 'xい'::nvarchar2(5)) || '|';
-
----- rpad(nvarchar2, int, nvarchar2)
+SELECT '|' || oracle.rpad('あbcd'::nvarchar2(5), 10, 'xい'::varchar2(5)) || '|';
 SELECT '|' || oracle.rpad('あbcd'::nvarchar2(5), 10, 'xい'::nvarchar2(5)) || '|';


### PR DESCRIPTION
These functions were added to primarily address following incompatibilities:

* pg_catalog.lpad and pg_catalog.rpad remove the trailing blanks of CHAR arguments
* pg_catalog.lpad and pg_catalog.rpad consider character length, not display length, so add custom C implementations and redefine SQL functions to use the custom implmentations

But, my original commit did not make this very clear. So, I have rearranged and added comments so that it's more clear. It should be helpful for maintainability.

NOTE: Actually, there is no need to separately define functions for VARCHAR2 and NVARCHAR2 because they can safely use text versions. But, in case of PG 8.3, it causes conflict because (N)VARCHAR2 can be implicit cast to both CHAR and text, so there is errors like below:

``
ERROR:  function oracle.lpad(character, integer, varchar2) is not unique
``

So, we need to separately keep those definitions to support 8.3 (it's not a problem for >= 8.4, because there is new feature typispreferred).

If there is some workaround for this, please share.