### PR TITLE
Fix Windows (MSVC) build for recently included files and related changes

### DIFF
--- a/builtins.h
+++ b/builtins.h
@@ -254,9 +254,23 @@ extern PGDLLEXPORT Datum dbms_utility_format_call_stack1(PG_FUNCTION_ARGS);
 extern void PGDLLEXPORT _PG_init(void);
 
 /* from charpad.c */
-extern PGDLLEXPORT Datum lpad(PG_FUNCTION_ARGS);
-extern PGDLLEXPORT Datum rpad(PG_FUNCTION_ARGS);
+extern PGDLLEXPORT Datum orafce_lpad(PG_FUNCTION_ARGS);
+extern PGDLLEXPORT Datum orafce_rpad(PG_FUNCTION_ARGS);
 
 /* from charlen.c */
-extern PGDLLEXPORT Datum bpcharlen(PG_FUNCTION_ARGS);
+extern PGDLLEXPORT Datum orafce_bpcharlen(PG_FUNCTION_ARGS);
+
+/* from varchar2.c */
+extern PGDLLEXPORT Datum varchar2in(PG_FUNCTION_ARGS);
+extern PGDLLEXPORT Datum varchar2out(PG_FUNCTION_ARGS);
+extern PGDLLEXPORT Datum varchar2(PG_FUNCTION_ARGS);
+extern PGDLLEXPORT Datum varchar2typmodin(PG_FUNCTION_ARGS);
+extern PGDLLEXPORT Datum varchar2recv(PG_FUNCTION_ARGS);
+
+/* from nvarchar2.c */
+extern PGDLLEXPORT Datum nvarchar2in(PG_FUNCTION_ARGS);
+extern PGDLLEXPORT Datum nvarchar2out(PG_FUNCTION_ARGS);
+extern PGDLLEXPORT Datum nvarchar2(PG_FUNCTION_ARGS);
+extern PGDLLEXPORT Datum nvarchar2typmodin(PG_FUNCTION_ARGS);
+extern PGDLLEXPORT Datum nvarchar2recv(PG_FUNCTION_ARGS);
 #endif

--- a/charlen.c
+++ b/charlen.c
@@ -22,12 +22,13 @@
 PG_MODULE_MAGIC;
 #endif
 
-extern Datum bpcharlen(PG_FUNCTION_ARGS);
+extern PGDLLEXPORT Datum orafce_bpcharlen(PG_FUNCTION_ARGS);
 
 PG_FUNCTION_INFO_V1(bpcharlen);
 
+PGDLLEXPORT
 Datum
-bpcharlen(PG_FUNCTION_ARGS)
+orafce_bpcharlen(PG_FUNCTION_ARGS)
 {
     BpChar     *arg = PG_GETARG_BPCHAR_PP(0);
     int         len; 

--- a/charpad.c
+++ b/charpad.c
@@ -24,20 +24,21 @@ PG_MODULE_MAGIC;
 #define PAD_MAX 4000
 
 /* Prototype declarations */
-extern Datum lpad(PG_FUNCTION_ARGS);
-extern Datum rpad(PG_FUNCTION_ARGS);
+extern PGDLLEXPORT Datum orafce_lpad(PG_FUNCTION_ARGS);
+extern PGDLLEXPORT Datum orafce_rpad(PG_FUNCTION_ARGS);
 
 PG_FUNCTION_INFO_V1(lpad);
 PG_FUNCTION_INFO_V1(rpad);
 
 /*
- * lpad(string text, length int32 [, fill text])
+ * orafce_lpad(string text, length int32 [, fill text])
  *
  * Fill up the string to length 'length' by prepending
  * the characters fill (a half-width space by default)
  */
+PGDLLEXPORT
 Datum
-lpad(PG_FUNCTION_ARGS)
+orafce_lpad(PG_FUNCTION_ARGS)
 {
 	text	*string1 = PG_GETARG_TEXT_PP(0);
 	int32	output_width = PG_GETARG_INT32(1);
@@ -261,13 +262,14 @@ lpad(PG_FUNCTION_ARGS)
 }
 
 /*
- * rpad(string text, length int32 [, fill text])
+ * orafce_rpad(string text, length int32 [, fill text])
  *
  * Fill up the string to length 'length' by appending
  * the characters fill (a half-width space by default)
  */
+PGDLLEXPORT
 Datum
-rpad(PG_FUNCTION_ARGS)
+orafce_rpad(PG_FUNCTION_ARGS)
 {
 	text	*string1 = PG_GETARG_TEXT_PP(0);
 	int32	output_width = PG_GETARG_INT32(1);

--- a/msvc/orafce.2010.vcxproj
+++ b/msvc/orafce.2010.vcxproj
@@ -30,7 +30,7 @@
     <ProjectGuid>{B6B37F22-9E44-4240-AAA0-650D4AC2C2E2}</ProjectGuid>
     <RootNamespace>lib</RootNamespace>
     <Keyword>Win32Proj</Keyword>
-    <ProjectName>orafunc</ProjectName>
+    <ProjectName>orafce</ProjectName>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='9.0|Win32'" Label="Configuration">
@@ -123,12 +123,12 @@
     <LibraryPath Condition="'$(Configuration)|$(Platform)'=='8.4|x64'">C:\Program Files %28x86%29\PostgreSQL\8.4\lib;$(LibraryPath)</LibraryPath>
     <LibraryPath Condition="'$(Configuration)|$(Platform)'=='8.3|Win32'">C:\Program Files %28x86%29\PostgreSQL\8.3\lib;$(LibraryPath)</LibraryPath>
     <LibraryPath Condition="'$(Configuration)|$(Platform)'=='8.3|x64'">C:\Program Files %28x86%29\PostgreSQL\8.3\lib;$(LibraryPath)</LibraryPath>
-    <TargetName Condition="'$(Configuration)|$(Platform)'=='9.0|Win32'">orafunc</TargetName>
-    <TargetName Condition="'$(Configuration)|$(Platform)'=='9.0|x64'">orafunc</TargetName>
-    <TargetName Condition="'$(Configuration)|$(Platform)'=='8.4|Win32'">orafunc</TargetName>
-    <TargetName Condition="'$(Configuration)|$(Platform)'=='8.4|x64'">orafunc</TargetName>
-    <TargetName Condition="'$(Configuration)|$(Platform)'=='8.3|Win32'">orafunc</TargetName>
-    <TargetName Condition="'$(Configuration)|$(Platform)'=='8.3|x64'">orafunc</TargetName>
+    <TargetName Condition="'$(Configuration)|$(Platform)'=='9.0|Win32'">orafce</TargetName>
+    <TargetName Condition="'$(Configuration)|$(Platform)'=='9.0|x64'">orafce</TargetName>
+    <TargetName Condition="'$(Configuration)|$(Platform)'=='8.4|Win32'">orafce</TargetName>
+    <TargetName Condition="'$(Configuration)|$(Platform)'=='8.4|x64'">orafce</TargetName>
+    <TargetName Condition="'$(Configuration)|$(Platform)'=='8.3|Win32'">orafce</TargetName>
+    <TargetName Condition="'$(Configuration)|$(Platform)'=='8.3|x64'">orafce</TargetName>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='9.0|Win32'">
     <ClCompile>
@@ -284,26 +284,26 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
-    <None Include="..\COPYRIGHT.orafunc" />
+    <None Include="..\COPYRIGHT.orafce" />
     <None Include="..\expected\dbms_output.out" />
     <None Include="..\expected\files.out" />
-    <None Include="..\expected\orafunc.out" />
-    <None Include="..\INSTALL.orafunc" />
-    <None Include="..\orafunc-8.1.sql" />
-    <None Include="..\orafunc-8.2.sql" />
-    <None Include="..\orafunc-8.3.sql" />
-    <None Include="..\orafunc-8.4.sql" />
-    <None Include="..\orafunc-9.0.sql" />
-    <None Include="..\orafunc-9.1.sql" />
-    <None Include="..\orafunc-common.sql" />
-    <None Include="..\README.orafunc" />
+    <None Include="..\expected\orafce.out" />
+    <None Include="..\INSTALL.orafce" />
+    <None Include="..\orafce-8.1.sql" />
+    <None Include="..\orafce-8.2.sql" />
+    <None Include="..\orafce-8.3.sql" />
+    <None Include="..\orafce-8.4.sql" />
+    <None Include="..\orafce-9.0.sql" />
+    <None Include="..\orafce-9.1.sql" />
+    <None Include="..\orafce-common.sql" />
+    <None Include="..\README.orafce" />
     <None Include="..\sqlparse.y" />
     <None Include="..\sqlscan.l" />
     <None Include="..\sql\dbms_output.sql" />
     <None Include="..\sql\dbms_pipe.sql" />
     <None Include="..\sql\files.sql" />
-    <None Include="..\sql\orafunc.sql" />
-    <None Include="..\uninstall_orafunc.sql" />
+    <None Include="..\sql\orafce.sql" />
+    <None Include="..\uninstall_orafce.sql" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\aggregate.c" />
@@ -324,11 +324,16 @@
     <ClCompile Include="..\random.c" />
     <ClCompile Include="..\shmmc.c" />
     <ClCompile Include="..\utility.c" />
+    <ClCompile Include="..\oraguc.c"/>
+    <ClCompile Include="..\charlen.c" />
+    <ClCompile Include="..\charpad.c" />
+    <ClCompile Include="..\nvarchar2.c" />
+    <ClCompile Include="..\varchar2.c" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\assert.h" />
     <ClInclude Include="..\builtins.h" />
-    <ClInclude Include="..\orafunc.h" />
+    <ClInclude Include="..\orafce.h" />
     <ClInclude Include="..\pipe.h" />
     <ClInclude Include="..\plvlex.h" />
     <ClInclude Include="..\shmmc.h" />

--- a/nvarchar2.c
+++ b/nvarchar2.c
@@ -20,12 +20,12 @@
 
 
 /* prototype declarations */
-extern Datum nvarchar2in(PG_FUNCTION_ARGS);			/* C string to internal
+extern PGDLLEXPORT Datum nvarchar2in(PG_FUNCTION_ARGS);			/* C string to internal
 													   NVARCHAR2 representation */
-extern Datum nvarchar2out(PG_FUNCTION_ARGS);			/* NVARCHAR2 to C string */
-extern Datum nvarchar2(PG_FUNCTION_ARGS);			/* NVARCHAR2 length check */
-extern Datum nvarchar2typmodin(PG_FUNCTION_ARGS);	/* type modifier internal conversion */
-extern Datum nvarchar2recv(PG_FUNCTION_ARGS);		/* external binary format to NVARCHAR2 */
+extern PGDLLEXPORT Datum nvarchar2out(PG_FUNCTION_ARGS);			/* NVARCHAR2 to C string */
+extern PGDLLEXPORT Datum nvarchar2(PG_FUNCTION_ARGS);			/* NVARCHAR2 length check */
+extern PGDLLEXPORT Datum nvarchar2typmodin(PG_FUNCTION_ARGS);	/* type modifier internal conversion */
+extern PGDLLEXPORT Datum nvarchar2recv(PG_FUNCTION_ARGS);		/* external binary format to NVARCHAR2 */
 
 PG_FUNCTION_INFO_V1(nvarchar2in);
 PG_FUNCTION_INFO_V1(nvarchar2out);
@@ -78,7 +78,7 @@ nvarchar2_input(const char *s, size_t len, int32 atttypmod)
  * Converts a C string to NVARCHAR2 internal representation.  atttypmod
  * is the declared length of the type plus VARHDRSZ.
  */
-
+PGDLLEXPORT
 Datum
 nvarchar2in(PG_FUNCTION_ARGS)
 {
@@ -100,7 +100,7 @@ nvarchar2in(PG_FUNCTION_ARGS)
  * Uses the text to C string conversion function, which is only appropriate
  * if VarChar and text are equivalent types.
  */
-
+PGDLLEXPORT
 Datum
 nvarchar2out(PG_FUNCTION_ARGS)
 {
@@ -112,7 +112,7 @@ nvarchar2out(PG_FUNCTION_ARGS)
 /*
  * converts external binary format to nvarchar
  */
-
+PGDLLEXPORT
 Datum
 nvarchar2recv(PG_FUNCTION_ARGS)
 {
@@ -157,6 +157,7 @@ nvarchar2recv(PG_FUNCTION_ARGS)
  * Truncation rules: for an explicit cast, silently truncate to the given
  * length; for an implicit cast, raise error if length limit is exceeded
  */
+PGDLLEXPORT
 Datum
 nvarchar2(PG_FUNCTION_ARGS)
 {

--- a/orafce--3.0.13.sql
+++ b/orafce--3.0.13.sql
@@ -2419,28 +2419,28 @@ WHERE proname='nvarchar2';
  */
 CREATE FUNCTION oracle.lpad(char, integer, char)
 RETURNS text
-AS 'MODULE_PATHNAME','lpad'
+AS 'MODULE_PATHNAME','orafce_lpad'
 LANGUAGE 'c'
 STRICT
 ;
 
 CREATE FUNCTION oracle.lpad(char, integer, text)
 RETURNS text
-AS 'MODULE_PATHNAME','lpad'
+AS 'MODULE_PATHNAME','orafce_lpad'
 LANGUAGE 'c'
 STRICT
 ;
 
 CREATE FUNCTION oracle.lpad(char, integer, varchar2)
 RETURNS text
-AS 'MODULE_PATHNAME','lpad'
+AS 'MODULE_PATHNAME','orafce_lpad'
 LANGUAGE 'c'
 STRICT
 ;
 
 CREATE FUNCTION oracle.lpad(char, integer, nvarchar2)
 RETURNS text
-AS 'MODULE_PATHNAME','lpad'
+AS 'MODULE_PATHNAME','orafce_lpad'
 LANGUAGE 'c'
 STRICT
 ;
@@ -2454,42 +2454,42 @@ STRICT
 
 CREATE FUNCTION oracle.lpad(text, integer, char)
 RETURNS text
-AS 'MODULE_PATHNAME','lpad'
+AS 'MODULE_PATHNAME','orafce_lpad'
 LANGUAGE 'c'
 STRICT
 ;
 
 CREATE FUNCTION oracle.lpad(varchar2, integer, char)
 RETURNS text
-AS 'MODULE_PATHNAME','lpad'
+AS 'MODULE_PATHNAME','orafce_lpad'
 LANGUAGE 'c'
 STRICT
 ;
 
 CREATE FUNCTION oracle.lpad(nvarchar2, integer, char)
 RETURNS text
-AS 'MODULE_PATHNAME','lpad'
+AS 'MODULE_PATHNAME','orafce_lpad'
 LANGUAGE 'c'
 STRICT
 ;
 
 CREATE FUNCTION oracle.lpad(text, integer, text)
 RETURNS text
-AS 'MODULE_PATHNAME','lpad'
+AS 'MODULE_PATHNAME','orafce_lpad'
 LANGUAGE 'c'
 STRICT
 ;
 
 CREATE FUNCTION oracle.lpad(text, integer, varchar2)
 RETURNS text
-AS 'MODULE_PATHNAME','lpad'
+AS 'MODULE_PATHNAME','orafce_lpad'
 LANGUAGE 'c'
 STRICT
 ;
 
 CREATE FUNCTION oracle.lpad(text, integer, nvarchar2)
 RETURNS text
-AS 'MODULE_PATHNAME','lpad'
+AS 'MODULE_PATHNAME','orafce_lpad'
 LANGUAGE 'c'
 STRICT
 ;
@@ -2503,21 +2503,21 @@ STRICT
 
 CREATE FUNCTION oracle.lpad(varchar2, integer, text)
 RETURNS text
-AS 'MODULE_PATHNAME','lpad'
+AS 'MODULE_PATHNAME','orafce_lpad'
 LANGUAGE 'c'
 STRICT
 ;
 
 CREATE FUNCTION oracle.lpad(varchar2, integer, varchar2)
 RETURNS text
-AS 'MODULE_PATHNAME','lpad'
+AS 'MODULE_PATHNAME','orafce_lpad'
 LANGUAGE 'c'
 STRICT
 ;
 
 CREATE FUNCTION oracle.lpad(varchar2, integer, nvarchar2)
 RETURNS text
-AS 'MODULE_PATHNAME','lpad'
+AS 'MODULE_PATHNAME','orafce_lpad'
 LANGUAGE 'c'
 STRICT
 ;
@@ -2531,21 +2531,21 @@ STRICT
 
 CREATE FUNCTION oracle.lpad(nvarchar2, integer, text)
 RETURNS text
-AS 'MODULE_PATHNAME','lpad'
+AS 'MODULE_PATHNAME','orafce_lpad'
 LANGUAGE 'c'
 STRICT
 ;
 
 CREATE FUNCTION oracle.lpad(nvarchar2, integer, varchar2)
 RETURNS text
-AS 'MODULE_PATHNAME','lpad'
+AS 'MODULE_PATHNAME','orafce_lpad'
 LANGUAGE 'c'
 STRICT
 ;
 
 CREATE FUNCTION oracle.lpad(nvarchar2, integer, nvarchar2)
 RETURNS text
-AS 'MODULE_PATHNAME','lpad'
+AS 'MODULE_PATHNAME','orafce_lpad'
 LANGUAGE 'c'
 STRICT
 ;
@@ -2570,28 +2570,28 @@ STRICT
  */
 CREATE FUNCTION oracle.rpad(char, integer, char)
 RETURNS text
-AS 'MODULE_PATHNAME','rpad'
+AS 'MODULE_PATHNAME','orafce_rpad'
 LANGUAGE 'c'
 STRICT
 ;
 
 CREATE FUNCTION oracle.rpad(char, integer, text)
 RETURNS text
-AS 'MODULE_PATHNAME','rpad'
+AS 'MODULE_PATHNAME','orafce_rpad'
 LANGUAGE 'c'
 STRICT
 ;
 
 CREATE FUNCTION oracle.rpad(char, integer, varchar2)
 RETURNS text
-AS 'MODULE_PATHNAME','rpad'
+AS 'MODULE_PATHNAME','orafce_rpad'
 LANGUAGE 'c'
 STRICT
 ;
 
 CREATE FUNCTION oracle.rpad(char, integer, nvarchar2)
 RETURNS text
-AS 'MODULE_PATHNAME','rpad'
+AS 'MODULE_PATHNAME','orafce_rpad'
 LANGUAGE 'c'
 STRICT
 ;
@@ -2605,42 +2605,42 @@ STRICT
 
 CREATE FUNCTION oracle.rpad(text, integer, char)
 RETURNS text
-AS 'MODULE_PATHNAME','rpad'
+AS 'MODULE_PATHNAME','orafce_rpad'
 LANGUAGE 'c'
 STRICT
 ;
 
 CREATE FUNCTION oracle.rpad(varchar2, integer, char)
 RETURNS text
-AS 'MODULE_PATHNAME','rpad'
+AS 'MODULE_PATHNAME','orafce_rpad'
 LANGUAGE 'c'
 STRICT
 ;
 
 CREATE FUNCTION oracle.rpad(nvarchar2, integer, char)
 RETURNS text
-AS 'MODULE_PATHNAME','rpad'
+AS 'MODULE_PATHNAME','orafce_rpad'
 LANGUAGE 'c'
 STRICT
 ;
 
 CREATE FUNCTION oracle.rpad(text, integer, text)
 RETURNS text
-AS 'MODULE_PATHNAME','rpad'
+AS 'MODULE_PATHNAME','orafce_rpad'
 LANGUAGE 'c'
 STRICT
 ;
 
 CREATE FUNCTION oracle.rpad(text, integer, varchar2)
 RETURNS text
-AS 'MODULE_PATHNAME','rpad'
+AS 'MODULE_PATHNAME','orafce_rpad'
 LANGUAGE 'c'
 STRICT
 ;
 
 CREATE FUNCTION oracle.rpad(text, integer, nvarchar2)
 RETURNS text
-AS 'MODULE_PATHNAME','rpad'
+AS 'MODULE_PATHNAME','orafce_rpad'
 LANGUAGE 'c'
 STRICT
 ;
@@ -2654,21 +2654,21 @@ STRICT
 
 CREATE FUNCTION oracle.rpad(varchar2, integer, text)
 RETURNS text
-AS 'MODULE_PATHNAME','rpad'
+AS 'MODULE_PATHNAME','orafce_rpad'
 LANGUAGE 'c'
 STRICT
 ;
 
 CREATE FUNCTION oracle.rpad(varchar2, integer, varchar2)
 RETURNS text
-AS 'MODULE_PATHNAME','rpad'
+AS 'MODULE_PATHNAME','orafce_rpad'
 LANGUAGE 'c'
 STRICT
 ;
 
 CREATE FUNCTION oracle.rpad(varchar2, integer, nvarchar2)
 RETURNS text
-AS 'MODULE_PATHNAME','rpad'
+AS 'MODULE_PATHNAME','orafce_rpad'
 LANGUAGE 'c'
 STRICT
 ;
@@ -2682,21 +2682,21 @@ STRICT
 
 CREATE FUNCTION oracle.rpad(nvarchar2, integer, text)
 RETURNS text
-AS 'MODULE_PATHNAME','rpad'
+AS 'MODULE_PATHNAME','orafce_rpad'
 LANGUAGE 'c'
 STRICT
 ;
 
 CREATE FUNCTION oracle.rpad(nvarchar2, integer, varchar2)
 RETURNS text
-AS 'MODULE_PATHNAME','rpad'
+AS 'MODULE_PATHNAME','orafce_rpad'
 LANGUAGE 'c'
 STRICT
 ;
 
 CREATE FUNCTION oracle.rpad(nvarchar2, integer, nvarchar2)
 RETURNS text
-AS 'MODULE_PATHNAME','rpad'
+AS 'MODULE_PATHNAME','orafce_rpad'
 LANGUAGE 'c'
 STRICT
 ;
@@ -3146,7 +3146,7 @@ STRICT
 /* LENGTH */
 CREATE FUNCTION oracle.length(char)
 RETURNS integer
-AS 'MODULE_PATHNAME','bpcharlen'
+AS 'MODULE_PATHNAME','orafce_bpcharlen'
 LANGUAGE 'c'
 STRICT
 ;

--- a/orafce-common.sql
+++ b/orafce-common.sql
@@ -2115,28 +2115,28 @@ typmod_out = nvarchar2typmodout
  */
 CREATE FUNCTION oracle.lpad(char, integer, char)
 RETURNS text
-AS 'MODULE_PATHNAME','lpad'
+AS 'MODULE_PATHNAME','orafce_lpad'
 LANGUAGE 'c'
 STRICT
 ;
 
 CREATE FUNCTION oracle.lpad(char, integer, text)
 RETURNS text
-AS 'MODULE_PATHNAME','lpad'
+AS 'MODULE_PATHNAME','orafce_lpad'
 LANGUAGE 'c'
 STRICT
 ;
 
 CREATE FUNCTION oracle.lpad(char, integer, varchar2)
 RETURNS text
-AS 'MODULE_PATHNAME','lpad'
+AS 'MODULE_PATHNAME','orafce_lpad'
 LANGUAGE 'c'
 STRICT
 ;
 
 CREATE FUNCTION oracle.lpad(char, integer, nvarchar2)
 RETURNS text
-AS 'MODULE_PATHNAME','lpad'
+AS 'MODULE_PATHNAME','orafce_lpad'
 LANGUAGE 'c'
 STRICT
 ;
@@ -2150,42 +2150,42 @@ STRICT
 
 CREATE FUNCTION oracle.lpad(text, integer, char)
 RETURNS text
-AS 'MODULE_PATHNAME','lpad'
+AS 'MODULE_PATHNAME','orafce_lpad'
 LANGUAGE 'c'
 STRICT
 ;
 
 CREATE FUNCTION oracle.lpad(varchar2, integer, char)
 RETURNS text
-AS 'MODULE_PATHNAME','lpad'
+AS 'MODULE_PATHNAME','orafce_lpad'
 LANGUAGE 'c'
 STRICT
 ;
 
 CREATE FUNCTION oracle.lpad(nvarchar2, integer, char)
 RETURNS text
-AS 'MODULE_PATHNAME','lpad'
+AS 'MODULE_PATHNAME','orafce_lpad'
 LANGUAGE 'c'
 STRICT
 ;
 
 CREATE FUNCTION oracle.lpad(text, integer, text)
 RETURNS text
-AS 'MODULE_PATHNAME','lpad'
+AS 'MODULE_PATHNAME','orafce_lpad'
 LANGUAGE 'c'
 STRICT
 ;
 
 CREATE FUNCTION oracle.lpad(text, integer, varchar2)
 RETURNS text
-AS 'MODULE_PATHNAME','lpad'
+AS 'MODULE_PATHNAME','orafce_lpad'
 LANGUAGE 'c'
 STRICT
 ;
 
 CREATE FUNCTION oracle.lpad(text, integer, nvarchar2)
 RETURNS text
-AS 'MODULE_PATHNAME','lpad'
+AS 'MODULE_PATHNAME','orafce_lpad'
 LANGUAGE 'c'
 STRICT
 ;
@@ -2199,21 +2199,21 @@ STRICT
 
 CREATE FUNCTION oracle.lpad(varchar2, integer, text)
 RETURNS text
-AS 'MODULE_PATHNAME','lpad'
+AS 'MODULE_PATHNAME','orafce_lpad'
 LANGUAGE 'c'
 STRICT
 ;
 
 CREATE FUNCTION oracle.lpad(varchar2, integer, varchar2)
 RETURNS text
-AS 'MODULE_PATHNAME','lpad'
+AS 'MODULE_PATHNAME','orafce_lpad'
 LANGUAGE 'c'
 STRICT
 ;
 
 CREATE FUNCTION oracle.lpad(varchar2, integer, nvarchar2)
 RETURNS text
-AS 'MODULE_PATHNAME','lpad'
+AS 'MODULE_PATHNAME','orafce_lpad'
 LANGUAGE 'c'
 STRICT
 ;
@@ -2227,21 +2227,21 @@ STRICT
 
 CREATE FUNCTION oracle.lpad(nvarchar2, integer, text)
 RETURNS text
-AS 'MODULE_PATHNAME','lpad'
+AS 'MODULE_PATHNAME','orafce_lpad'
 LANGUAGE 'c'
 STRICT
 ;
 
 CREATE FUNCTION oracle.lpad(nvarchar2, integer, varchar2)
 RETURNS text
-AS 'MODULE_PATHNAME','lpad'
+AS 'MODULE_PATHNAME','orafce_lpad'
 LANGUAGE 'c'
 STRICT
 ;
 
 CREATE FUNCTION oracle.lpad(nvarchar2, integer, nvarchar2)
 RETURNS text
-AS 'MODULE_PATHNAME','lpad'
+AS 'MODULE_PATHNAME','orafce_lpad'
 LANGUAGE 'c'
 STRICT
 ;
@@ -2266,28 +2266,28 @@ STRICT
  */
 CREATE FUNCTION oracle.rpad(char, integer, char)
 RETURNS text
-AS 'MODULE_PATHNAME','rpad'
+AS 'MODULE_PATHNAME','orafce_rpad'
 LANGUAGE 'c'
 STRICT
 ;
 
 CREATE FUNCTION oracle.rpad(char, integer, text)
 RETURNS text
-AS 'MODULE_PATHNAME','rpad'
+AS 'MODULE_PATHNAME','orafce_rpad'
 LANGUAGE 'c'
 STRICT
 ;
 
 CREATE FUNCTION oracle.rpad(char, integer, varchar2)
 RETURNS text
-AS 'MODULE_PATHNAME','rpad'
+AS 'MODULE_PATHNAME','orafce_rpad'
 LANGUAGE 'c'
 STRICT
 ;
 
 CREATE FUNCTION oracle.rpad(char, integer, nvarchar2)
 RETURNS text
-AS 'MODULE_PATHNAME','rpad'
+AS 'MODULE_PATHNAME','orafce_rpad'
 LANGUAGE 'c'
 STRICT
 ;
@@ -2301,42 +2301,42 @@ STRICT
 
 CREATE FUNCTION oracle.rpad(text, integer, char)
 RETURNS text
-AS 'MODULE_PATHNAME','rpad'
+AS 'MODULE_PATHNAME','orafce_rpad'
 LANGUAGE 'c'
 STRICT
 ;
 
 CREATE FUNCTION oracle.rpad(varchar2, integer, char)
 RETURNS text
-AS 'MODULE_PATHNAME','rpad'
+AS 'MODULE_PATHNAME','orafce_rpad'
 LANGUAGE 'c'
 STRICT
 ;
 
 CREATE FUNCTION oracle.rpad(nvarchar2, integer, char)
 RETURNS text
-AS 'MODULE_PATHNAME','rpad'
+AS 'MODULE_PATHNAME','orafce_rpad'
 LANGUAGE 'c'
 STRICT
 ;
 
 CREATE FUNCTION oracle.rpad(text, integer, text)
 RETURNS text
-AS 'MODULE_PATHNAME','rpad'
+AS 'MODULE_PATHNAME','orafce_rpad'
 LANGUAGE 'c'
 STRICT
 ;
 
 CREATE FUNCTION oracle.rpad(text, integer, varchar2)
 RETURNS text
-AS 'MODULE_PATHNAME','rpad'
+AS 'MODULE_PATHNAME','orafce_rpad'
 LANGUAGE 'c'
 STRICT
 ;
 
 CREATE FUNCTION oracle.rpad(text, integer, nvarchar2)
 RETURNS text
-AS 'MODULE_PATHNAME','rpad'
+AS 'MODULE_PATHNAME','orafce_rpad'
 LANGUAGE 'c'
 STRICT
 ;
@@ -2350,21 +2350,21 @@ STRICT
 
 CREATE FUNCTION oracle.rpad(varchar2, integer, text)
 RETURNS text
-AS 'MODULE_PATHNAME','rpad'
+AS 'MODULE_PATHNAME','orafce_rpad'
 LANGUAGE 'c'
 STRICT
 ;
 
 CREATE FUNCTION oracle.rpad(varchar2, integer, varchar2)
 RETURNS text
-AS 'MODULE_PATHNAME','rpad'
+AS 'MODULE_PATHNAME','orafce_rpad'
 LANGUAGE 'c'
 STRICT
 ;
 
 CREATE FUNCTION oracle.rpad(varchar2, integer, nvarchar2)
 RETURNS text
-AS 'MODULE_PATHNAME','rpad'
+AS 'MODULE_PATHNAME','orafce_rpad'
 LANGUAGE 'c'
 STRICT
 ;
@@ -2378,21 +2378,21 @@ STRICT
 
 CREATE FUNCTION oracle.rpad(nvarchar2, integer, text)
 RETURNS text
-AS 'MODULE_PATHNAME','rpad'
+AS 'MODULE_PATHNAME','orafce_rpad'
 LANGUAGE 'c'
 STRICT
 ;
 
 CREATE FUNCTION oracle.rpad(nvarchar2, integer, varchar2)
 RETURNS text
-AS 'MODULE_PATHNAME','rpad'
+AS 'MODULE_PATHNAME','orafce_rpad'
 LANGUAGE 'c'
 STRICT
 ;
 
 CREATE FUNCTION oracle.rpad(nvarchar2, integer, nvarchar2)
 RETURNS text
-AS 'MODULE_PATHNAME','rpad'
+AS 'MODULE_PATHNAME','orafce_rpad'
 LANGUAGE 'c'
 STRICT
 ;
@@ -2842,7 +2842,7 @@ STRICT
 /* LENGTH */
 CREATE FUNCTION oracle.length(char)
 RETURNS integer
-AS 'MODULE_PATHNAME','bpcharlen'
+AS 'MODULE_PATHNAME','orafce_bpcharlen'
 LANGUAGE 'c'
 STRICT
 ;

--- a/varchar2.c
+++ b/varchar2.c
@@ -20,12 +20,12 @@
 
 
 /* prototype declarations */
-extern Datum varchar2in(PG_FUNCTION_ARGS);			/* C string to internal
+extern PGDLLEXPORT Datum varchar2in(PG_FUNCTION_ARGS);			/* C string to internal
 													   VARCHAR2 representation */
-extern Datum varchar2out(PG_FUNCTION_ARGS);			/* VARCHAR2 to C string */
-extern Datum varchar2(PG_FUNCTION_ARGS);			/* VARCHAR2 length check */
-extern Datum varchar2typmodin(PG_FUNCTION_ARGS);	/* type modifier internal conversion */
-extern Datum varchar2recv(PG_FUNCTION_ARGS);		/* external binary format to VARCHAR2 */
+extern PGDLLEXPORT Datum varchar2out(PG_FUNCTION_ARGS);			/* VARCHAR2 to C string */
+extern PGDLLEXPORT Datum varchar2(PG_FUNCTION_ARGS);			/* VARCHAR2 length check */
+extern PGDLLEXPORT Datum varchar2typmodin(PG_FUNCTION_ARGS);	/* type modifier internal conversion */
+extern PGDLLEXPORT Datum varchar2recv(PG_FUNCTION_ARGS);		/* external binary format to VARCHAR2 */
 
 PG_FUNCTION_INFO_V1(varchar2in);
 PG_FUNCTION_INFO_V1(varchar2out);
@@ -70,7 +70,7 @@ varchar2_input(const char *s, size_t len, int32 atttypmod)
  * Converts a C string to VARCHAR2 internal representation.  atttypmod
  * is the declared length of the type plus VARHDRSZ.
  */
-
+PGDLLEXPORT
 Datum
 varchar2in(PG_FUNCTION_ARGS)
 {
@@ -92,7 +92,7 @@ varchar2in(PG_FUNCTION_ARGS)
  * Uses the text to C string conversion function, which is only appropriate
  * if VarChar and text are equivalent types.
  */
-
+PGDLLEXPORT
 Datum
 varchar2out(PG_FUNCTION_ARGS)
 {
@@ -104,7 +104,7 @@ varchar2out(PG_FUNCTION_ARGS)
 /*
  * converts external binary format to varchar
  */
-
+PGDLLEXPORT
 Datum
 varchar2recv(PG_FUNCTION_ARGS)
 {
@@ -149,6 +149,7 @@ varchar2recv(PG_FUNCTION_ARGS)
  * Truncation rules: for an explicit cast, silently truncate to the given
  * length; for an implicit cast, raise error if length limit is exceeded
  */
+PGDLLEXPORT
 Datum
 varchar2(PG_FUNCTION_ARGS)
 {


### PR DESCRIPTION
The msvc/orafce.2010.vcxproj file did not consider following files:

oraguc.c
charlen.c
charpad.c
nvarchar2.c
varchar2.c

Make related changes. Additionally mark various symbols with PGDLLEXPORT as appropriate.

Note: even with these changes, we need to rebuild PostgreSQL after marking two symbols days[] and session_timezone with PGDLLIMPORT. Otherwise there are errors like:

Compiler Error C2370 redefinition; different storage class

when building orafce.

By the way, I have used Microsoft Visual Studio Express 2013 with postgres built from postgresql-9.4.0.tar.gz.