### PR TITLE
Fix recently discovered errors in regression tests

### DIFF
--- a/charlen.c
+++ b/charlen.c
@@ -24,7 +24,7 @@ PG_MODULE_MAGIC;
 
 extern PGDLLEXPORT Datum orafce_bpcharlen(PG_FUNCTION_ARGS);
 
-PG_FUNCTION_INFO_V1(bpcharlen);
+PG_FUNCTION_INFO_V1(orafce_bpcharlen);
 
 PGDLLEXPORT
 Datum

--- a/charpad.c
+++ b/charpad.c
@@ -27,8 +27,8 @@ PG_MODULE_MAGIC;
 extern PGDLLEXPORT Datum orafce_lpad(PG_FUNCTION_ARGS);
 extern PGDLLEXPORT Datum orafce_rpad(PG_FUNCTION_ARGS);
 
-PG_FUNCTION_INFO_V1(lpad);
-PG_FUNCTION_INFO_V1(rpad);
+PG_FUNCTION_INFO_V1(orafce_lpad);
+PG_FUNCTION_INFO_V1(orafce_rpad);
 
 /*
  * orafce_lpad(string text, length int32 [, fill text])

--- a/expected/dbms_pipe_session_A.out
+++ b/expected/dbms_pipe_session_A.out
@@ -9,73 +9,105 @@
             0
 (1 row)
 
+SELECT createImplicitPipe();
  createimplicitpipe 
 --------------------
  
 (1 row)
 
+-- Bulk send messages
+SELECT bulkSend();
  bulksend 
 ----------
  
 (1 row)
 
+-- An explicit private pipe
+SELECT notify('recv_private1_notifier');
  notify 
 --------
  
 (1 row)
 
+SELECT createExplicitPipe('private_pipe_1',3);
  createexplicitpipe 
 --------------------
  
 (1 row)
 
+-- An explicit private pipe
+SELECT notify('recv_private2_notifier');
  notify 
 --------
  
 (1 row)
 
+SELECT createExplicitPipe('private_pipe_2',3);
  createexplicitpipe 
 --------------------
  
 (1 row)
 
+-- An explicit public pipe (uses two-argument create_pipe)
+SELECT notify('recv_public1_notifier');
  notify 
 --------
  
 (1 row)
 
+SELECT createExplicitPipe('public_pipe_3',2);
  createexplicitpipe 
 --------------------
  
 (1 row)
 
+-- An explicit public pipe (uses one-argument create_pipe)
+SELECT notify('recv_public2_notifier');
  notify 
 --------
  
 (1 row)
 
+SELECT createExplicitPipe('public_pipe_4',1);
  createexplicitpipe 
 --------------------
  
 (1 row)
 
+-- tests send_message(text)
+SELECT checkSend1();
  checksend1 
 ------------
  
 (1 row)
 
+-- tests send_message(text,integer)
+SELECT checkSend2();
  checksend2 
 ------------
  
 (1 row)
 
+SELECT notifyDropTemp();
  notifydroptemp 
 ----------------
  
 (1 row)
 
+-- tests unique_session_name()
+SELECT checkUniqueSessionNameA();
  checkuniquesessionnamea 
 -------------------------
  
 (1 row)
 
+DROP FUNCTION createImplicitPipe();
+DROP FUNCTION createExplicitPipe(text,integer);
+DROP FUNCTION createPipe(text,integer);
+DROP FUNCTION checkSend1();
+DROP FUNCTION checkSend2();
+DROP FUNCTION checkUniqueSessionNameA();
+DROP FUNCTION bulkSend();
+DROP FUNCTION notifyDropTemp();
+DROP FUNCTION notify(text);
+DROP FUNCTION send(text);

--- a/expected/dbms_pipe_session_B.out
+++ b/expected/dbms_pipe_session_B.out
@@ -4,6 +4,8 @@
                0
 (1 row)
 
+-- Receives messages sent via an implicit pipe
+SELECT receiveFrom('named_pipe');
 NOTICE:  RECEIVE 11: Message From Session A
 NOTICE:  RECEIVE 12: 01-01-2013
 NOTICE:  RECEIVE 13: Tue Jan 01 09:00:00 2013 PST
@@ -18,6 +20,8 @@ NOTICE:  RECEIVE 24: (2,rob)
  
 (1 row)
 
+-- Bulk receive messages
+SELECT bulkReceive();
 NOTICE:  RECEIVE 11: Message From Session A
 NOTICE:  RECEIVE 12: 01-01-2013
 NOTICE:  RECEIVE 13: Tue Jan 01 09:00:00 2013 PST
@@ -32,11 +36,15 @@ NOTICE:  RECEIVE 24: (2,rob)
  
 (1 row)
 
+-- Receives messages sent via an explicit private pipe under the same user
+-- 'pipe_test_owner'
+SELECT dbms_pipe.receive_message('recv_private1_notifier');
  receive_message 
 -----------------
                0
 (1 row)
 
+SELECT receiveFrom('private_pipe_1');
 NOTICE:  RECEIVE 11: Message From Session A
 NOTICE:  RECEIVE 12: 01-01-2013
 NOTICE:  RECEIVE 13: Tue Jan 01 09:00:00 2013 PST
@@ -51,18 +59,31 @@ NOTICE:  RECEIVE 24: (2,rob)
  
 (1 row)
 
+-- Switch user to 'pipe_test_other'
+DROP USER IF EXISTS pipe_test_other;
 NOTICE:  role "pipe_test_other" does not exist, skipping
+CREATE USER pipe_test_other;
+SET SESSION AUTHORIZATION pipe_test_other;
+-- Try to receive messages sent via an explicit private pipe under the user
+-- 'pipe_test_other' who is not the owner of pipe.
+-- insufficient privileges in case of 'private_pipe_2'.
+SELECT dbms_pipe.receive_message('recv_private2_notifier');
  receive_message 
 -----------------
                0
 (1 row)
 
+SELECT receiveFrom('private_pipe_2');
 ERROR:  insufficient privilege
+-- These are explicit private pipes created using create_pipe(text,integer)
+-- and create_pipe(text)
+SELECT dbms_pipe.receive_message('recv_public1_notifier');
  receive_message 
 -----------------
                0
 (1 row)
 
+SELECT receiveFrom('public_pipe_3');
 NOTICE:  RECEIVE 11: Message From Session A
 NOTICE:  RECEIVE 12: 01-01-2013
 NOTICE:  RECEIVE 13: Tue Jan 01 09:00:00 2013 PST
@@ -77,11 +98,13 @@ NOTICE:  RECEIVE 24: (2,rob)
  
 (1 row)
 
+SELECT dbms_pipe.receive_message('recv_public2_notifier');
  receive_message 
 -----------------
                0
 (1 row)
 
+SELECT receiveFrom('public_pipe_4');
 NOTICE:  RECEIVE 11: Message From Session A
 NOTICE:  RECEIVE 12: 01-01-2013
 NOTICE:  RECEIVE 13: Tue Jan 01 09:00:00 2013 PST
@@ -96,24 +119,41 @@ NOTICE:  RECEIVE 24: (2,rob)
  
 (1 row)
 
+-- Switch back to user 'pipe_test_owner'
+SET SESSION AUTHORIZATION pipe_test_owner;
+DROP USER pipe_test_other;
+-- Tests receive_message(text)
+SELECT checkReceive1('pipe_name_1');
 NOTICE:  RECEIVE checking one-argument send_message()
  checkreceive1 
 ---------------
  
 (1 row)
 
+SELECT checkReceive1('pipe_name_2');
 NOTICE:  RECEIVE checking two-argument send_message()
  checkreceive1 
 ---------------
  
 (1 row)
 
+-- Tests dbms_pipe.db_pipes view
+SELECT name, items, "limit", private, owner
+FROM dbms_pipe.db_pipes
+WHERE name LIKE 'private%'
+ORDER BY name;
       name      | items | limit | private |      owner      
 ----------------+-------+-------+---------+-----------------
  private_pipe_1 |     0 |    10 | t       | pipe_test_owner
  private_pipe_2 |     9 |    10 | t       | pipe_test_owner
 (2 rows)
 
+-- Tests dbms_pipe.__list_pipes(); attribute size is not included
+-- since it can be different across runs.
+SELECT name, items, "limit", private, owner
+FROM dbms_pipe.__list_pipes()  AS  (name varchar, items int4, siz int4, "limit" int4, private bool, owner varchar)
+WHERE name <> 'pipe_name_4'
+ORDER BY 1;
       name      | items | limit | private |      owner      
 ----------------+-------+-------+---------+-----------------
  pipe_name_3    |     1 |       | f       | 
@@ -123,63 +163,86 @@ NOTICE:  RECEIVE checking two-argument send_message()
  public_pipe_4  |     0 |    10 | f       | 
 (5 rows)
 
+-- Tests remove_pipe(text)
+SELECT dbms_pipe.remove_pipe('private_pipe_1');
  remove_pipe 
 -------------
  
 (1 row)
 
+SELECT dbms_pipe.remove_pipe('private_pipe_2');
  remove_pipe 
 -------------
  
 (1 row)
 
+SELECT dbms_pipe.remove_pipe('public_pipe_3');
  remove_pipe 
 -------------
  
 (1 row)
 
+SELECT dbms_pipe.remove_pipe('public_pipe_4');
  remove_pipe 
 -------------
  
 (1 row)
 
+SELECT dbms_pipe.purge('pipe_name_1');
  purge 
 -------
  
 (1 row)
 
+SELECT dbms_pipe.purge('pipe_name_2');
  purge 
 -------
  
 (1 row)
 
+-- Receives drop table notification from session A via 'pipe_name_3'
+SELECT  dropTempTable();
  droptemptable 
 ---------------
  
 (1 row)
 
+SELECT dbms_pipe.purge('pipe_name_3');
  purge 
 -------
  
 (1 row)
 
+-- tests unique_session_name() (uses 'pipe_name_4')
+SELECT checkUniqueSessionNameB();
  checkuniquesessionnameb 
 -------------------------
  f
 (1 row)
 
+SELECT dbms_pipe.purge('pipe_name_4');
  purge 
 -------
  
 (1 row)
 
+DROP FUNCTION receiveFrom(text);
+DROP FUNCTION checkReceive1(text);
+DROP FUNCTION checkUniqueSessionNameB();
+DROP FUNCTION bulkReceive();
+DROP FUNCTION dropTempTable();
+-- Perform a recieve on removed pipe resulting on timeout
+SELECT dbms_pipe.receive_message('public_pipe_4',2);
  receive_message 
 -----------------
                1
 (1 row)
 
+SELECT dbms_pipe.purge('public_pipe_4');
  purge 
 -------
  
 (1 row)
 
+SET SESSION AUTHORIZATION DEFAULT;
+DROP USER pipe_test_owner;

--- a/sql/dbms_pipe_session_A.sql
+++ b/sql/dbms_pipe_session_A.sql
@@ -14,7 +14,7 @@ SELECT dbms_pipe.send_message('pipe_test_owner_created_notifier');
 -- Create a new connection under the userid of pipe_test_owner
 SET SESSION AUTHORIZATION pipe_test_owner;
 
-/* create an implicit pipe and sends message using 
+/* create an implicit pipe and sends message using
  * send_message(text,integer,integer)
  */
 CREATE OR REPLACE FUNCTION send(pipename text) RETURNS void AS $$
@@ -70,8 +70,8 @@ BEGIN
 END; $$ LANGUAGE plpgsql;
 
 
-/* Creates an explicit pipe using either create_pipe(text,integer,bool), 
- * create_pipe(text,integer) OR create_pipe(text). 
+/* Creates an explicit pipe using either create_pipe(text,integer,bool),
+ * create_pipe(text,integer) OR create_pipe(text).
  * In case third parameter (bool) absent, default is false, that is, it's a public pipe.
  */
 CREATE OR REPLACE FUNCTION createPipe(name text,ver integer) RETURNS void AS $$
@@ -86,8 +86,8 @@ BEGIN
 END; $$ LANGUAGE plpgsql;
 
 
-/* Testing create_pipe for different versions, one of them, is the case of 
- * private pipe 
+/* Testing create_pipe for different versions, one of them, is the case of
+ * private pipe
  */
 
 CREATE OR REPLACE FUNCTION createExplicitPipe(pipename text,create_version integer) RETURNS void AS $$
@@ -159,7 +159,7 @@ BEGIN
 	PERFORM dbms_pipe.send_message(pipename);
 END; $$ LANGUAGE plpgsql;
 
-\set ECHO all;
+\set ECHO all
 
 SELECT createImplicitPipe();
 
@@ -183,10 +183,10 @@ SELECT notify('recv_public2_notifier');
 SELECT createExplicitPipe('public_pipe_4',1);
 
 -- tests send_message(text)
-SELECT checkSend1(); 
+SELECT checkSend1();
 
 -- tests send_message(text,integer)
-SELECT checkSend2(); 
+SELECT checkSend2();
 
 SELECT notifyDropTemp();
 

--- a/sql/dbms_pipe_session_B.sql
+++ b/sql/dbms_pipe_session_B.sql
@@ -6,7 +6,7 @@ SELECT dbms_pipe.receive_message('pipe_test_owner_created_notifier');
 -- create new connection under the userid of 'pipe_test_owner'
 SET SESSION AUTHORIZATION pipe_test_owner;
 
-/* Tests receive_message(text,integer), next_item_type() and all versions of 
+/* Tests receive_message(text,integer), next_item_type() and all versions of
  *  unpack_message_<type>() and  purge(text)
  */
 
@@ -24,9 +24,9 @@ BEGIN
                 ELSIF typ=13 THEN RAISE NOTICE 'RECEIVE %: %', typ, dbms_pipe.unpack_message_timestamp();
                 ELSIF typ=23 THEN RAISE NOTICE 'RECEIVE %: %', typ, encode(dbms_pipe.unpack_message_bytea(),'escape');
                 ELSIF typ=24 THEN RAISE NOTICE 'RECEIVE %: %', typ, dbms_pipe.unpack_message_record();
-                END IF;                 
+                END IF;
         END LOOP;
-        PERFORM dbms_pipe.purge(pipename);      
+        PERFORM dbms_pipe.purge(pipename);
 END;
 $$ LANGUAGE plpgsql;
 
@@ -48,7 +48,7 @@ BEGIN
                 ELSIF typ=13 THEN RAISE NOTICE 'RECEIVE %: %', typ, dbms_pipe.unpack_message_timestamp();
                 ELSIF typ=23 THEN RAISE NOTICE 'RECEIVE %: %', typ, encode(dbms_pipe.unpack_message_bytea()::bytea,'escape');
                 ELSIF typ=24 THEN RAISE NOTICE 'RECEIVE %: %', typ, dbms_pipe.unpack_message_record();
-                END IF;                 
+                END IF;
         END LOOP;
         PERFORM dbms_pipe.purge('named_pipe_2');
 END;
@@ -80,7 +80,7 @@ BEGIN
 	RETURN result;
 END; $$ LANGUAGE plpgsql;
 
-\set ECHO all;
+\set ECHO all
 
 -- Receives messages sent via an implicit pipe
 SELECT receiveFrom('named_pipe');
@@ -98,14 +98,14 @@ DROP USER IF EXISTS pipe_test_other;
 CREATE USER pipe_test_other;
 SET SESSION AUTHORIZATION pipe_test_other;
 
--- Try to receive messages sent via an explicit private pipe under the user 
+-- Try to receive messages sent via an explicit private pipe under the user
 -- 'pipe_test_other' who is not the owner of pipe.
 -- insufficient privileges in case of 'private_pipe_2'.
 
 SELECT dbms_pipe.receive_message('recv_private2_notifier');
 SELECT receiveFrom('private_pipe_2');
 
--- These are explicit private pipes created using create_pipe(text,integer) 
+-- These are explicit private pipes created using create_pipe(text,integer)
 -- and create_pipe(text)
 SELECT dbms_pipe.receive_message('recv_public1_notifier');
 SELECT receiveFrom('public_pipe_3');
@@ -122,16 +122,16 @@ SELECT checkReceive1('pipe_name_1');
 SELECT checkReceive1('pipe_name_2');
 
 -- Tests dbms_pipe.db_pipes view
-SELECT name, items, "limit", private, owner 
-FROM dbms_pipe.db_pipes 
-WHERE name LIKE 'private%' 
+SELECT name, items, "limit", private, owner
+FROM dbms_pipe.db_pipes
+WHERE name LIKE 'private%'
 ORDER BY name;
 
--- Tests dbms_pipe.__list_pipes(); attribute size is not included 
+-- Tests dbms_pipe.__list_pipes(); attribute size is not included
 -- since it can be different across runs.
-SELECT name, items, "limit", private, owner  
+SELECT name, items, "limit", private, owner
 FROM dbms_pipe.__list_pipes()  AS  (name varchar, items int4, siz int4, "limit" int4, private bool, owner varchar)
-WHERE name <> 'pipe_name_4' 
+WHERE name <> 'pipe_name_4'
 ORDER BY 1;
 
 -- Tests remove_pipe(text)


### PR DESCRIPTION
Following fixes are needed for recent failures of regression tests

1) fix PG_FUNCTION_INFO_V1 declarations of lpad, rpad and bpcharlen that were recently renamed (this was reported on discussion group recently)

https://groups.google.com/d/msg/orafce-general/1OV9297FvDU/zHWqnLhRwS4J

2) I recently found that \set ECHO all; (with the trailing semicolon) causes following error:

+ unrecognized value "all;" for "ECHO"; assuming "none"

So, get rid of them in dbms_pipe regression test scripts. I also fixed some extraneous whitespace in the same commit.