### PR TITLE
Fix NLS-enabled build on OS X

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,11 +57,7 @@ include $(PGXS)
 endif
 
 ifeq ($(enable_nls), yes)
-ifeq ($(PORTNAME),win32)
-SHLIB_LINK += -lintl
-else
-SHLIB_LINK += -L$(libdir)/gettextlib
-endif
+SHLIB_LINK += $(filter -lintl,$(LIBS))
 endif
 
 # remove dependency to libxml2 and libxslt


### PR DESCRIPTION
OS X requires all symbols in the module to be resolved at build time.
This requires -lintl if the build is NLS-enabled.  The previous code
only did this on Windows, but it's really appropriate for all
platforms.  The previous code for non-Windows didn't make sense.