### PR TITLE
fix enquote_name(), bizdays_between(), and rvrs()

### DIFF
--- a/assert.c
+++ b/assert.c
@@ -161,6 +161,9 @@ dbms_assert_enquote_name(PG_FUNCTION_ARGS)
 	bool loweralize = PG_GETARG_BOOL(1);
 	Oid collation = PG_GET_COLLATION();
 
+	if (PG_ARGISNULL(0))
+		PG_RETURN_NULL();
+
 	name = DirectFunctionCall1(quote_ident, name);
 
 	if (loweralize)

--- a/plvdate.c
+++ b/plvdate.c
@@ -300,7 +300,7 @@ ora_diff_bizdays(DateADT day1, DateADT day2)
 		if (cycle_c == 1)
 			start_is_bizday = true;
 	}
-	if (include_start && start_is_bizday && days >= 1)
+	if (days > 0 && !(include_start && start_is_bizday))
 		days -= 1;
 
 	return days;


### PR DESCRIPTION
* If `dbms_assert.enquote_name()` is invoked with NULL value, SIGSEGV
  occurs.
  Fix it to return NULL value if the first parameter is NULL value.

* When `plvdate.bizdays_between('2016-02-24', '2016-02-26')` is invoked,
    1 is returned if `plvdate.including_start()` is true and
    2 is returned if `plvdate.including_start()` is false.
  Fix it to return 2 and 1 respectively.

* `plvstr.rvrs()` does not check `start` and `end` correctly.
  In some cases, SIGSEGV occurs. And if the first parameter is NULL
  value, also SIGSEGV occurs.
  Fix it to throw PARAMETER_ERROR if `start` and `end` are out of bound.
  And fix it not to generate SIGSEGV if the first parameter is NULL
  value. Finally, it can now process negative `start` and `end`
  correctly.