### PR TITLE
Avoid setting unused variable value

### DIFF
--- a/utility.c
+++ b/utility.c
@@ -132,8 +132,6 @@ dbms_utility_format_call_stack(char mode)
 					p1[p2i] = '\0';
 					line = pstrdup(p1);
 					p1[p2i] = c;
-
-					start = p1 + p2i;
 				}
 			}
 


### PR DESCRIPTION
After being set here, start is overwritten in the eol case before being used again. In the non-eol case, the loop ends and start is no longer used. Remove the extraneous variable setting to reduce confusion.

Unless of course, I am confused =)