### PR TITLE
fix the position of a half-width space added by rpad().

### DIFF
--- a/charpad.c
+++ b/charpad.c
@@ -416,19 +416,6 @@ orafce_rpad(PG_FUNCTION_ARGS)
 	ret = (text *) palloc(VARHDRSZ + total_blen);
 	ptr_ret = VARDATA(ret);
 
-	/*
-	 * add a half-width space as a padding necessary to satisfy the required
-	 * output_width
-	 *
-	 * (memory already allocated as reserved by either s1_add_blen
-	 *  or s2_add_blen)
-	 */
-	if (half_space)
-	{
-		memcpy(ptr_ret, spc, hslen);
-		ptr_ret += hslen;
-	}
-
 	/* string1 */
 	while(s1_add_blen > 0)
 	{
@@ -478,6 +465,19 @@ orafce_rpad(PG_FUNCTION_ARGS)
 		/* when get to the end of string2, reset ptr2 back to the start */
 		if (ptr2 == ptr2end)
 			ptr2 = ptr2start;
+	}
+
+	/*
+	 * add a half-width space as a padding necessary to satisfy the required
+	 * output_width
+	 *
+	 * (memory already allocated as reserved by either s1_add_blen
+	 *  or s2_add_blen)
+	 */
+	if (half_space)
+	{
+		memcpy(ptr_ret, spc, hslen);
+		ptr_ret += hslen;
 	}
 
 	SET_VARSIZE(ret, ptr_ret - (char *) ret);

--- a/expected/orafce.out
+++ b/expected/orafce.out
@@ -3976,7 +3976,7 @@ SELECT '|' || oracle.rpad('あbcd'::text,  5, 'xい'::char(3)) || '|';
 SELECT '|' || oracle.rpad('あbcd'::varchar2(5), 10, 'xい'::char(3)) || '|';
    ?column?   
 --------------
- | あbcxい x|
+ |あbcxい x |
 (1 row)
 
 SELECT '|' || oracle.rpad('あbcd'::varchar2(5),  5, 'xい'::char(3)) || '|';
@@ -4037,19 +4037,19 @@ SELECT '|' || oracle.rpad('あbcd'::nvarchar2(10), 5) || '|';
 SELECT '|' || oracle.rpad('あbcd'::text, 10, 'xい'::text) || '|';
    ?column?   
 --------------
- | あbcdxいx|
+ |あbcdxいx |
 (1 row)
 
 SELECT '|' || oracle.rpad('あbcd'::text, 10, 'xい'::varchar2(5)) || '|';
    ?column?   
 --------------
- | あbcdxいx|
+ |あbcdxいx |
 (1 row)
 
 SELECT '|' || oracle.rpad('あbcd'::text, 10, 'xい'::nvarchar2(3)) || '|';
    ?column?   
 --------------
- | あbcdxいx|
+ |あbcdxいx |
 (1 row)
 
 SELECT '|' || oracle.rpad('あbcd'::varchar2(5), 10, 'xい'::text) || '|';
@@ -4073,19 +4073,19 @@ SELECT '|' || oracle.rpad('あbcd'::varchar2(5), 10, 'xい'::nvarchar2(5)) || '|
 SELECT '|' || oracle.rpad('あbcd'::nvarchar2(5), 10, 'xい'::text) || '|';
    ?column?   
 --------------
- | あbcdxいx|
+ |あbcdxいx |
 (1 row)
 
 SELECT '|' || oracle.rpad('あbcd'::nvarchar2(5), 10, 'xい'::varchar2(5)) || '|';
    ?column?   
 --------------
- | あbcdxいx|
+ |あbcdxいx |
 (1 row)
 
 SELECT '|' || oracle.rpad('あbcd'::nvarchar2(5), 10, 'xい'::nvarchar2(5)) || '|';
    ?column?   
 --------------
- | あbcdxいx|
+ |あbcdxいx |
 (1 row)
 
 --


### PR DESCRIPTION
rpad() pads a half-width space at the end of line, not at the
beggining of line to satisfy the required output_width when it pads
 multibyte characters.