### PR TITLE
Translation of REGEXP_SUBSTR

### DIFF
--- a/doc/sql_migration/sql_migration03.md
+++ b/doc/sql_migration/sql_migration03.md
@@ -489,7 +489,97 @@ The example below shows migration when a regular expression pattern is used to c
 </tbody>
 </table>
 
-### 3.7 TO_TIMESTAMP
+### 3.7 REGEXP_SUBSTR
+
+**Description**
+
+REGEXP_SUBSTR extract a substring from a string using regular expression pattern matching
+
+**Functional differences**
+
+ - **Oracle database**
+     - Return the substring that match the regular expression pattern from the string.
+ - **PostgreSQL**
+     - REGEXP_SUBSTR is not available.
+
+**Migration procedure**
+
+The REGEXP_MATCHES combinated to the ARRAY_TO_STRING function of PostgreSQL can be used to return the same result following the different parameters of the Oracle function. Use the following procedure to perform migration:
+ 
+ 1. Search for the keyword REGEXP_SUBSTR and identify where it is used.
+ 2. Replace the keyword REGEXP_SUBSTR by REGEXP_MATCHES
+ 3. Specify the argument 'g' as embedded option in the third argument of REGEXP_MATCHES to search for all occurences.
+ 4. Use this function in the FROM clause of a SELECT ARRAY_TO_STRING() statement and limit the number of rows returned by this statement to 1 using LIMIT.
+ 5. If the third parameter of REGEXP_SUBSTR is greater than 1 use it as the start position of the SUBSTR function called on the first argument of the REGEXP_MATCHES function.
+ 6. If the fourth parameter is greater than 1 append a call to OFFSET with a value set to this parameter minus 1 to return the substring found at this position.
+ 7. If there is a fifth parameter to the REGEXP_SUBSTR() function append it to 'g', the embedded regular expression option of the REGEXP_MATCHES call.
+
+**Migration example**
+
+The example below shows migration when a regular expression pattern is used to extract a string.
+
+<table>
+<thead>
+<tr>
+<th align="center">Oracle database</th>
+<th align="center">PostgreSQL</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td align="left">
+<pre><code>
+SELECT
+    REGEXP_SUBSTR('one two three four five ', '(\S*)\s')
+FROM DUAL;
+Result: one
+
+SELECT
+    REGEXP_SUBSTR('one two three four five ', '(\S*)\s', 1, 3)
+FROM DUAL;
+Result: three
+
+SELECT
+    REGEXP_SUBSTR('one two three four five ', '(\S*)\s', 5, 3)
+FROM DUAL;
+Result: four
+
+SELECT
+    REGEXP_SUBSTR('one two three four five ', '(\S*)\s', 1, 1, 'i')
+FROM DUAL;
+Result: one
+ </code></pre>
+</td>
+
+<td align="left">
+<pre><code>
+SELECT (SELECT array_to_string(a, '') AS "REGEXP"
+    FROM regexp_matches('one two three four five ', '(\S*)\s', 'g') AS f(a)
+    LIMIT 1);
+Result: one
+
+SELECT (SELECT array_to_string(a, '') AS "REGEXP"
+    FROM regexp_matches('one two three four five ', '(\S*)\s', 'g') AS f(a)
+    LIMIT 1 OFFSET (3 - 1));
+Result: three
+
+SELECT (SELECT array_to_string(a, '') AS "REGEXP"
+    FROM regexp_matches(substring('one two three four five ', 5), '(\S*)\s', 'g') AS f(a)
+    LIMIT 1 OFFSET (3 - 1));
+Result: four
+
+SELECT (SELECT array_to_string(a, '') AS "REGEXP"
+    FROM regexp_matches('one two three four five ', '(\S*)\s', 'gi') AS f(a)
+    LIMIT 1);
+Result: one
+ </code></pre>
+</td>
+</tr>
+</tbody>
+</table>
+
+
+### 3.8 TO_TIMESTAMP
 
 **Description**
 

--- a/doc/sql_migration/sql_migration03.md
+++ b/doc/sql_migration/sql_migration03.md
@@ -530,47 +530,86 @@ The example below shows migration when a regular expression pattern is used to e
 <td align="left">
 <pre><code>
 SELECT
-    REGEXP_SUBSTR('one two three four five ', '(\S*)\s')
-FROM DUAL;
-Result: one
-
-SELECT
-    REGEXP_SUBSTR('one two three four five ', '(\S*)\s', 1, 3)
-FROM DUAL;
-Result: three
-
-SELECT
-    REGEXP_SUBSTR('one two three four five ', '(\S*)\s', 5, 3)
-FROM DUAL;
-Result: four
-
-SELECT
-    REGEXP_SUBSTR('one two three four five ', '(\S*)\s', 1, 1, 'i')
+    REGEXP_SUBSTR('one two three four five ',
+	'(\S*)\s') AS "REGEXP"
 FROM DUAL;
 Result: one
  </code></pre>
 </td>
-
 <td align="left">
 <pre><code>
-SELECT (SELECT array_to_string(a, '') AS "REGEXP"
-    FROM regexp_matches('one two three four five ', '(\S*)\s', 'g') AS f(a)
-    LIMIT 1);
+SELECT (
+    SELECT array_to_string(a, '') AS "REGEXP"
+    FROM regexp_matches('one two three four five ',
+	'(\S*)\s',
+	'g') AS f(a)
+    LIMIT 1
+);
 Result: one
-
-SELECT (SELECT array_to_string(a, '') AS "REGEXP"
-    FROM regexp_matches('one two three four five ', '(\S*)\s', 'g') AS f(a)
-    LIMIT 1 OFFSET (3 - 1));
+ </code></pre>
+</td>
+</tr><tr>
+<td align="left">
+<pre><code>
+SELECT
+    REGEXP_SUBSTR('one two three four five ',
+	'(\S*)\s', 1, 3) AS "REGEXP"
+FROM DUAL;
 Result: three
-
-SELECT (SELECT array_to_string(a, '') AS "REGEXP"
-    FROM regexp_matches(substring('one two three four five ', 5), '(\S*)\s', 'g') AS f(a)
-    LIMIT 1 OFFSET (3 - 1));
+ </code></pre>
+</td>
+<td align="left">
+<pre><code>
+SELECT (
+    SELECT array_to_string(a, '') AS "REGEXP"
+    FROM regexp_matches('one two three four five ',
+	'(\S*)\s', 'g') AS f(a)
+    LIMIT 1 OFFSET (3 - 1)
+);
+Result: three
+ </code></pre>
+</td>
+</tr><tr>
+<td align="left">
+<pre><code>
+SELECT
+    REGEXP_SUBSTR('one two three four five ',
+	'(\S*)\s', 5, 3)  AS "REGEXP"
+FROM DUAL;
 Result: four
-
-SELECT (SELECT array_to_string(a, '') AS "REGEXP"
-    FROM regexp_matches('one two three four five ', '(\S*)\s', 'gi') AS f(a)
-    LIMIT 1);
+ </code></pre>
+</td>
+<td align="left">
+<pre><code>
+SELECT (
+    SELECT array_to_string(a, '') AS "REGEXP"
+    FROM regexp_matches(substring(
+		'one two three four five ',
+		5
+	), '(\S*)\s', 'g') AS f(a)
+    LIMIT 1 OFFSET (3 - 1)
+);
+Result: four
+ </code></pre>
+</td>
+</tr><tr>
+<td align="left">
+<pre><code>
+SELECT
+    REGEXP_SUBSTR('one two three four five ',
+	'(\S*)\s', 1, 1, 'i')
+FROM DUAL;
+Result: one
+ </code></pre>
+</td>
+<td align="left">
+<pre><code>
+SELECT (
+    SELECT array_to_string(a, '') AS "REGEXP"
+    FROM regexp_matches('one two three four five ',
+	'(\S*)\s', 'gi') AS f(a)
+    LIMIT 1
+);
 Result: one
  </code></pre>
 </td>


### PR DESCRIPTION
Function REGEXP_SUBSTR() doe not exists in PostgreSQL but it can be translated using the following rule.

Translation of `REGEX_SUBSTR( string, pattern, [pos], [nth])` can be converted into:
```
        SELECT array_to_string(a, '')
          FROM regexp_matches(substr(string, pos), pattern, 'g') AS foo(a)
          LIMIT 1 OFFSET (nth - 1);
```
Optional fifth parameter of match_parameter is appended to 'g' when present.