### PR TITLE
Fix build for PostgreSQL 12

### DIFF
--- a/nvarchar2.c
+++ b/nvarchar2.c
@@ -134,7 +134,7 @@ nvarchar2recv(PG_FUNCTION_ARGS)
  * length >= the previous maximum length.  We can ignore the isExplicit
  * argument, since that only affects truncation cases.
  *
- * just use varchar_transform()
+ * just use varchar_support()
  */
 
 /*

--- a/orafce--3.7.sql
+++ b/orafce--3.7.sql
@@ -2122,7 +2122,7 @@ IMMUTABLE;
 
 CREATE FUNCTION varchar2_transform(internal)
 RETURNS internal
-AS 'varchar_transform'
+AS 'varchar_support'
 LANGUAGE internal
 STRICT
 IMMUTABLE;
@@ -2282,7 +2282,7 @@ WITH INOUT
 AS IMPLICIT;
 
 UPDATE pg_proc
-SET protransform=(SELECT oid FROM pg_proc WHERE proname='varchar2_transform')
+SET prosupport=(SELECT oid FROM pg_proc WHERE proname='varchar2_transform')
 WHERE proname='varchar2';
 
 -- string functions for varchar2 type
@@ -2330,7 +2330,7 @@ IMMUTABLE;
 
 CREATE FUNCTION nvarchar2_transform(internal)
 RETURNS internal
-AS 'varchar_transform'
+AS 'varchar_support'
 LANGUAGE internal
 STRICT
 IMMUTABLE;
@@ -2490,7 +2490,7 @@ WITH INOUT
 AS IMPLICIT;
 
 UPDATE pg_proc
-SET protransform=(SELECT oid FROM pg_proc WHERE proname='varchar2_transform')
+SET prosupport=(SELECT oid FROM pg_proc WHERE proname='varchar2_transform')
 WHERE proname='nvarchar2';
 
 /*

--- a/varchar2.c
+++ b/varchar2.c
@@ -129,7 +129,7 @@ varchar2recv(PG_FUNCTION_ARGS)
  * length >= the previous maximum length.  We can ignore the isExplicit
  * argument, since that only affects truncation cases.
  *
- * just use varchar_transform()
+ * just use varchar_support()
  */
 
 /*


### PR DESCRIPTION
pg_proc.protransform was renamed to pg_proc.prosupport.
Also, varchar_transform() was renamed to varchar_support().
- 1fb57af92069ee104c09e2016af9e0e620681be3