### PR TITLE
Fix the wrong filter in oracle.user_tables view in orafce--3.6--3.7.sql.

### DIFF
--- a/orafce--3.6--3.7.sql
+++ b/orafce--3.6--3.7.sql
@@ -30,6 +30,13 @@ RETURNS TIMESTAMP
 AS $$ SELECT (pg_catalog.add_months($1::pg_catalog.date, $2) + $1::time)::oracle.date; $$
 LANGUAGE SQL IMMUTABLE STRICT;
 
+drop view oracle.user_tables;
+
+create view oracle.user_tables as
+    select table_name
+      from information_schema.tables
+     where table_type = 'BASE TABLE';
+
 -- new functionality
 CREATE FUNCTION oracle.orafce_concat2(varchar2, varchar2)
 RETURNS varchar2


### PR DESCRIPTION
Hi

I found the bug when updating orafce from version 3.6 to newer version.

commit 9ed58cf fixes filter in oracle.user_tables view, but the bug remains
when updating orafce from 3.6 to newer version by
ALTER EXTENSION orafce UPDATE because orafce--3.6--3.7.sql does not have this fix.

This PR fix this. 

Regards,
Daisuke, Higuchi.