### PR TITLE
dual should return a row with no content

### DIFF
--- a/orafce--3.14.sql
+++ b/orafce--3.14.sql
@@ -469,10 +469,11 @@ CREATE FUNCTION oracle.dbtimezone()
 RETURNS text
 AS 'MODULE_PATHNAME','orafce_dbtimezone'
 LANGUAGE C STABLE STRICT;
-COMMENT ON FUNCTION oracle.dbtimezone() IS 'Ruturns server time zone (orafce.timezone)';
+COMMENT ON FUNCTION oracle.dbtimezone() IS 'Returns server time zone (orafce.timezone)';
 
 -- emulation of dual table
-CREATE VIEW public.dual AS SELECT 'X'::varchar AS dummy;
+CREATE OR REPLACE VIEW public.dual AS SELECT;
+COMMENT ON VIEW public.dual IS 'emulation of the dual talbe, single row with no content';
 REVOKE ALL ON public.dual FROM PUBLIC;
 GRANT SELECT, REFERENCES ON public.dual TO PUBLIC;
 


### PR DESCRIPTION
Defining table DUAL as "create view public.dual as select;" creates a view that returns an empty row, which comes closer to the Oracle thing I think.