### PR TITLE
Add Oracle regexp_replace() function

### DIFF
--- a/doc/orafce_documentation/Orafce_Documentation_01.md
+++ b/doc/orafce_documentation/Orafce_Documentation_01.md
@@ -60,6 +60,7 @@ The table below lists features compatible with Oracle databases.
 |REGEXP_INSTR|returns the beginning or ending position within the string where the match for a pattern was located|
 |REGEXP_LIKE|condition in the WHERE clause of a query, causing the query to return rows that match the given pattern|
 |REGEXP_SUBSTR|returns the string that matches the pattern specified in the call to the function|
+|REGEXP_REPLACE|replace substring(s) matching a POSIX regular expression|
 |RPAD|Right-pads a string to a specified length with a sequence of characters|
 |RTRIM|Removes the specified characters from the end of a string|
 |SUBSTR|Extracts part of a string using characters to specify position and length|

--- a/doc/orafce_documentation/Orafce_Documentation_05.md
+++ b/doc/orafce_documentation/Orafce_Documentation_05.md
@@ -766,7 +766,50 @@ SELECT regexp_substr('1234567890 1234567890', '(123)(4(56)(78))', 1, 1, 'i', 0) 
 
 ----
 
-#### 5.2.12 RPAD
+#### 5.2.12 REGEXP_REPLACE
+
+**Description**
+
+Returns the string that matches the pattern specified in the call to the function.
+
+**Syntax**
+
+![REGEXP_REPLACE]( gif/REGEXP_REPLACE.gif) 
+
+**General rules**
+
+ - REGEXP_REPLACE returns a modified version of the source string where occurrences of a POSIX regular expression pattern found in the source string are replaced with the specified replacement string. If no match is found or the occurrence queried exceed the number of match, then the source string untouched is returned.
+ - The search and replacement starts from the specified start position *startPos* in *string*, default starts from the beginning of *string*.
+ - *startPos* is a positive integer, negative values to search from the end of *string* are not allowed.
+ - *occurrence* is a positive integer indicating which occurrence of *pattern* in *string* should be search for and replaced. The default is 0, meaning all occurrences of *pattern* in *string*.
+ - *flags* is a character expression that lets you change the default matching behavior of the function.  See [REGEXP_COUNT](#REGEXP_COUNT) for detailed information.
+
+**Example**
+
+~~~
+SELECT regexp_replace('512.123.4567 612.123.4567', '([[:digit:]]{3})\.([[:digit:]]{3})\.([[:digit:]]{4})', '(\1) \2-\3') FROM DUAL;
+        regexp_replace
+-------------------------------
+ (512) 123-4567 (612) 123-4567
+(1 row)
+
+SELECT oracle.REGEXP_REPLACE('number   your     street,    zipcode  town, FR', '( ){2,}', ' ', 9);
+             regexp_replace             
+----------------------------------------
+ number   your street, zipcode town, FR
+(1 row)
+
+SELECT oracle.REGEXP_REPLACE('number   your     street,    zipcode  town, FR', '( ){2,}', ' ', 9, 2);
+               regexp_replace                
+---------------------------------------------
+ number   your     street, zipcode  town, FR
+(1 row)
+~~~
+
+----
+
+#### 5.2.13 RPAD
+
 **Description**
 
 Right-pads a string to a specified length with a sequence of characters.
@@ -827,7 +870,7 @@ SELECT RPAD('abc',10,'a') FROM DUAL;
 
 ----
 
-#### 5.2.13 RTRIM
+#### 5.2.14 RTRIM
 
 **Description**
 
@@ -889,7 +932,7 @@ SELECT RTRIM('aabcab','ab') FROM DUAL;
 
 ----
 
-#### 5.2.14 SUBSTR
+#### 5.2.15 SUBSTR
 
 **Description**
 
@@ -967,7 +1010,7 @@ SELECT SUBSTR('ABCDEFG',-5,4) "Substring" FROM DUAL;
 ----
 
 
-#### 5.2.15 SUBSTRB
+#### 5.2.16 SUBSTRB
 
 **Description**
 

--- a/expected/regexp_func.out
+++ b/expected/regexp_func.out
@@ -542,3 +542,136 @@ SELECT REGEXP_SUBSTR('1234567890 1234567890', '(123)(4(56)(78))', 1, -1, 'i', 0)
 ERROR:  argument 'occurence' must be a number greater than 0
 SELECT REGEXP_SUBSTR('1234567890 1234567890', '(123)(4(56)(78))', 1, 1, 'i', -1);
 ERROR:  argument 'group' must be a positive number
+----
+-- Tests for REGEXP_REPLACE()
+----
+-- ORACLE> SELECT REGEXP_REPLACE('512.123.4567', '([[:digit:]]{3})\.([[:digit:]]{3})\.([[:digit:]]{4})', '(\1) \2-\3') FROM DUAL; -> (512) 123-4567
+SELECT REGEXP_REPLACE('512.123.4567', '([[:digit:]]{3})\.([[:digit:]]{3})\.([[:digit:]]{4})', '(\1) \2-\3');
+ regexp_replace 
+----------------
+ (512) 123-4567
+(1 row)
+
+-- ORACLE> SELECT REGEXP_REPLACE('512.123.4567 612.123.4567', '([[:digit:]]{3})\.([[:digit:]]{3})\.([[:digit:]]{4})', '(\1) \2-\3') FROM DUAL; -> (512) 123-4567 (612) 123-4567
+SELECT oracle.REGEXP_REPLACE('512.123.4567 612.123.4567', '([[:digit:]]{3})\.([[:digit:]]{3})\.([[:digit:]]{4})', '(\1) \2-\3');
+        regexp_replace         
+-------------------------------
+ (512) 123-4567 (612) 123-4567
+(1 row)
+
+-- ORACLE> SELECT REGEXP_REPLACE('number   your     street,    zipcode  town, FR', '( ){2,}', ' ') FROM DUAL; -> number your street, zipcode town, FR
+SELECT oracle.REGEXP_REPLACE('number   your     street,    zipcode  town, FR', '( ){2,}', ' ');
+            regexp_replace            
+--------------------------------------
+ number your street, zipcode town, FR
+(1 row)
+
+-- ORACLE> SELECT REGEXP_REPLACE('number   your     street,'||CHR(10)||'    zipcode  town, FR', '( ){2,}', ' ') FROM DUAL; -> number your street,
+-- zipcode town, FR
+SELECT oracle.REGEXP_REPLACE('number   your     street,'||CHR(10)||'    zipcode  town, FR', '( ){2,}', ' ');
+   regexp_replace    
+---------------------
+ number your street,+
+  zipcode town, FR
+(1 row)
+
+-- ORACLE> SELECT REGEXP_REPLACE('number   your     street,    zipcode  town, FR', '( ){2,}', ' ', 9) FROM DUAL; -> number    your street, zipcode town, FR
+SELECT oracle.REGEXP_REPLACE('number   your     street,    zipcode  town, FR', '( ){2,}', ' ', 9);
+             regexp_replace             
+----------------------------------------
+ number   your street, zipcode town, FR
+(1 row)
+
+-- ORACLE> SELECT REGEXP_REPLACE('number   your     street,    zipcode  town, FR', '( ){2,}', ' ', 9, 0) FROM DUAL; -> number    your street, zipcode town, FR
+SELECT oracle.REGEXP_REPLACE('number   your     street,    zipcode  town, FR', '( ){2,}', ' ', 9, 0);
+             regexp_replace             
+----------------------------------------
+ number   your street, zipcode town, FR
+(1 row)
+
+-- ORACLE> SELECT REGEXP_REPLACE('number   your     street,    zipcode  town, FR', '( ){2,}', ' ', 9, 2) FROM DUAL; -> number    your     street, zipcode  town, FR
+SELECT oracle.REGEXP_REPLACE('number   your     street,    zipcode  town, FR', '( ){2,}', ' ', 9, 2);
+               regexp_replace                
+---------------------------------------------
+ number   your     street, zipcode  town, FR
+(1 row)
+
+-- ORACLE> SELECT REGEXP_REPLACE('number   your     street,    zipcode  town, FR', '( ){2,}', ' ', 9, 2, 'm') FROM DUAL; -> number    your     street, zipcode  town, FR
+SELECT oracle.REGEXP_REPLACE('number   your     street,    zipcode  town, FR', '( ){2,}', ' ', 9, 2, 'm');
+               regexp_replace                
+---------------------------------------------
+ number   your     street, zipcode  town, FR
+(1 row)
+
+-- ORACLE> SELECT REGEXP_REPLACE('number   your     street,    zipcode  town, FR', '([EURT]){2,}', '[\1]', 9, 2, 'i') FROM DUAL; -> number    your     s[t],    zipcode  town, FR
+SELECT oracle.REGEXP_REPLACE('number   your     street,    zipcode  town, FR', '([EURT]){2,}', '[\1]', 9, 2, 'i');
+                regexp_replace                
+----------------------------------------------
+ number   your     s[t],    zipcode  town, FR
+(1 row)
+
+-- ORACLE> SELECT REGEXP_REPLACE('number   your     street,    zipcode  town, FR', '[ ]{2,}', ' ', 9, 2) FROM DUAL; -> number    your     street, zipcode  town, FR
+SELECT oracle.REGEXP_REPLACE('number   your     street,    zipcode  town, FR', '( ){2,}', ' ', 9, 2);
+               regexp_replace                
+---------------------------------------------
+ number   your     street, zipcode  town, FR
+(1 row)
+
+-- ORACLE> SELECT REGEXP_REPLACE ('A PostgreSQL function', 'A|e|i|o|u', 'X', 1, 2) FROM DUAL; -> A PXstgreSQL function
+SELECT oracle.REGEXP_REPLACE ('A PostgreSQL function', 'A|e|i|o|u', 'X', 1, 2);
+    regexp_replace     
+-----------------------
+ A PXstgreSQL function
+(1 row)
+
+-- ORACLE> SELECT REGEXP_REPLACE ('A PostgreSQL function', 'a|e|i|o|u', 'X', 1, 0, 'i') FROM DUAL; -> X PXstgrXSQL fXnctXXn
+SELECT oracle.REGEXP_REPLACE ('A PostgreSQL function', 'a|e|i|o|u', 'X', 1, 0, 'i');
+    regexp_replace     
+-----------------------
+ X PXstgrXSQL fXnctXXn
+(1 row)
+
+-- ORACLE> SELECT REGEXP_REPLACE ('A PostgreSQL function', 'a|e|i|o|u', 'X', 1, 1, 'i') FROM DUAL; -> X PostgreSQL function
+SELECT oracle.REGEXP_REPLACE ('A PostgreSQL function', 'a|e|i|o|u', 'X', 1, 1, 'i');
+    regexp_replace     
+-----------------------
+ X PostgreSQL function
+(1 row)
+
+-- ORACLE> SELECT REGEXP_REPLACE ('A PostgreSQL function', 'a|e|i|o|u', 'X', 1, 2, 'i') FROM DUAL; -> A PXstgreSQL function
+SELECT oracle.REGEXP_REPLACE ('A PostgreSQL function', 'a|e|i|o|u', 'X', 1, 2, 'i');
+    regexp_replace     
+-----------------------
+ A PXstgreSQL function
+(1 row)
+
+-- ORACLE> SELECT REGEXP_REPLACE ('A PostgreSQL function', 'a|e|i|o|u', 'X', 1, 3, 'i') FROM DUAL; -> A PostgrXSQL function
+SELECT oracle.REGEXP_REPLACE ('A PostgreSQL function', 'a|e|i|o|u', 'X', 1, 3, 'i');
+    regexp_replace     
+-----------------------
+ A PostgrXSQL function
+(1 row)
+
+-- ORACLE> SELECT REGEXP_REPLACE ('A PostgreSQL function', 'a|e|i|o|u', 'X', 1, 9, 'i') FROM DUAL; -> A PostgreSQL function
+SELECT oracle.REGEXP_REPLACE ('A PostgreSQL function', 'a|e|i|o|u', 'X', 1, 9, 'i');
+    regexp_replace     
+-----------------------
+ A PostgreSQL function
+(1 row)
+
+-- ORACLE> SELECT REGEXP_REPLACE ('A PostgreSQL function', 'A|e|i|o|u', 'X', 1, 9) FROM DUAL; -> A PostgreSQL function
+SELECT oracle.REGEXP_REPLACE ('A PostgreSQL function', 'A|e|i|o|u', 'X', 1, 9);
+    regexp_replace     
+-----------------------
+ A PostgreSQL function
+(1 row)
+
+-- ORACLE> SELECT REGEXP_REPLACE ('A PostgreSQL function', 'a|e|i|o|u', 'X', -1, 0, 'i') FROM DUAL; -> ORA-01428
+SELECT oracle.REGEXP_REPLACE ('A PostgreSQL function', 'a|e|i|o|u', 'X', -1, 0, 'i');
+ERROR:  argument 'position' must be a number greater than 0
+-- ORACLE> SELECT REGEXP_REPLACE ('A PostgreSQL function', 'a|e|i|o|u', 'X', 1, -1, 'i') FROM DUAL; -> ORA-01428
+SELECT oracle.REGEXP_REPLACE ('A PostgreSQL function', 'a|e|i|o|u', 'X', 1, -1, 'i');
+ERROR:  argument 'occurrence' must be a positive number
+-- ORACLE> SELECT REGEXP_REPLACE ('A PostgreSQL function', 'a|e|i|o|u', 'X', 1, 1, 'g') FROM DUAL; -> ORA-01760
+SELECT oracle.REGEXP_REPLACE ('A PostgreSQL function', 'a|e|i|o|u', 'X', 1, 1, 'g');
+ERROR:  argument 'flags' has unsupported modifier(s).

--- a/orafce--3.14--3.15.sql
+++ b/orafce--3.14--3.15.sql
@@ -7,6 +7,12 @@ AS $$
 DECLARE
   modifiers text;
 BEGIN
+  -- Check that we don't have modifier not supported by Oracle
+  IF regexp_match($1, '[^icnsmx]') IS NOT NULL THEN
+    -- Modifier 's' is not supported by Oracle but it is a synonym
+    -- of 'n', we translate 'n' into 's' bellow. It is safe to allow it.
+    RAISE EXCEPTION 'argument ''flags'' has unsupported modifier(s).';
+  END IF;
   -- Oracle 'n' modifier correspond to 's' POSIX modifier
   -- Oracle 'm' modifier correspond to 'n' POSIX modifier
   modifiers := translate($1, 'nm', 'sn');
@@ -498,3 +504,129 @@ BEGIN
 END;
 $$
 LANGUAGE plpgsql;
+
+-- REGEXP_REPLACE( string text, pattern text, replace_string text ) -> text
+CREATE OR REPLACE FUNCTION oracle.regexp_replace(text, text, text)
+RETURNS text
+AS $$
+  -- Oracle default behavior is to replace all occurence
+  -- whereas PostgreSQL only replace the first occurrence
+  -- so we need to add 'g' modifier.
+  SELECT pg_catalog.regexp_replace($1, $2, $3, 'g');
+$$
+LANGUAGE sql;
+
+-- REGEXP_REPLACE( string text, pattern text, replace_string text, position int ) -> text
+CREATE OR REPLACE FUNCTION oracle.regexp_replace(text, text, text, integer)
+RETURNS text
+AS $$
+DECLARE
+  v_replaced_str text;
+  v_before text;
+BEGIN
+  -- Check numeric arguments
+  IF $4 < 1 THEN
+    RAISE EXCEPTION 'argument ''position'' must be a number greater than 0';
+  END IF;
+
+  v_before = substr($1, 1, $4 - 1);
+
+  -- Oracle default behavior is to replace all occurence
+  -- whereas PostgreSQL only replace the first occurrence
+  -- so we need to add 'g' modifier.
+  v_replaced_str := v_before || pg_catalog.regexp_replace(substr($1, $4), $2, $3, 'g');
+  RETURN v_replaced_str;
+END;
+$$
+LANGUAGE plpgsql;
+
+-- REGEXP_REPLACE( string text, pattern text, replace_string text, position int, occurence int ) -> text
+CREATE OR REPLACE FUNCTION oracle.regexp_replace(text, text, text, integer, integer)
+RETURNS text
+AS $$
+DECLARE
+  v_replaced_str text;
+  v_pos integer := $4;
+  v_before text := '';
+  v_nummatch integer;
+BEGIN
+  -- Check numeric arguments
+  IF $4 < 1 THEN
+    RAISE EXCEPTION 'argument ''position'' must be a number greater than 0';
+  END IF;
+  IF $5 < 0 THEN
+    RAISE EXCEPTION 'argument ''occurrence'' must be a positive number';
+  END IF;
+  -- Check if the occurrence queried exceeds the number of occurrences
+  IF $5 > 1 THEN
+    v_nummatch := (SELECT count(*) FROM regexp_matches(substr($1, $4), $2, 'g'));
+    IF $5 > v_nummatch THEN
+      RETURN $1;
+    END IF;
+    -- Get the position of the occurrence we are looking for
+    v_pos := oracle.regexp_instr($1, $2, $4, $5, 0, '', 1);
+    IF v_pos = 0 THEN
+      RETURN $1;
+    END IF;
+  END IF;
+  -- Get the substring before this position we will need to restore it
+  v_before := substr($1, 1, v_pos - 1);
+
+  -- Replace all occurrences
+  IF $5 = 0 THEN
+    v_replaced_str := v_before || pg_catalog.regexp_replace(substr($1, v_pos), $2, $3, 'g');
+  ELSE
+    -- Replace the first occurrence
+    v_replaced_str := v_before || pg_catalog.regexp_replace(substr($1, v_pos), $2, $3);
+  END IF;
+
+  RETURN v_replaced_str;
+END;
+$$
+LANGUAGE plpgsql;
+
+-- REGEXP_REPLACE( string text, pattern text, replace_string text, position int, occurence int, flags text ) -> text
+CREATE OR REPLACE FUNCTION oracle.regexp_replace(text, text, text, integer, integer, text)
+RETURNS text
+AS $$
+DECLARE
+  v_replaced_str text;
+  v_pos integer := $4;
+  v_nummatch integer;
+  v_before text := '';
+  modifiers text := '';
+BEGIN
+  -- Check numeric arguments
+  IF $4 < 1 THEN
+    RAISE EXCEPTION 'argument ''position'' must be a number greater than 0';
+  END IF;
+  IF $5 < 0 THEN
+    RAISE EXCEPTION 'argument ''occurrence'' must be a positive number';
+  END IF;
+  -- Set the modifiers
+  IF $5 = 0 THEN
+    modifiers := oracle.translate_oracle_modifiers($6, true);
+  ELSE
+    modifiers := oracle.translate_oracle_modifiers($6, false);
+  END IF;
+  -- Check if the occurrence queried exceeds the number of occurrences
+  IF $5 > 1 THEN
+    v_nummatch := (SELECT count(*) FROM regexp_matches(substr($1, $4), $2, $6||'g'));
+    IF $5 > v_nummatch THEN
+      RETURN $1;
+    END IF;
+    -- Get the position of the occurrence we are looking for
+    v_pos := oracle.regexp_instr($1, $2, $4, $5, 0, $6, 1);
+    IF v_pos = 0 THEN
+      RETURN $1;
+    END IF;
+  END IF;
+  -- Get the substring before this position we will need to restore it
+  v_before := substr($1, 1, v_pos - 1);
+  -- Replace occurrence(s)
+  v_replaced_str := v_before || pg_catalog.regexp_replace(substr($1, v_pos), $2, $3, modifiers);
+  RETURN v_replaced_str;
+END;
+$$
+LANGUAGE plpgsql;
+

--- a/sql/regexp_func.sql
+++ b/sql/regexp_func.sql
@@ -200,3 +200,50 @@ SELECT REGEXP_SUBSTR('1234567890 1234567890', '(123)(4(56)(78))', -1, 1, 'i', 0)
 SELECT REGEXP_SUBSTR('1234567890 1234567890', '(123)(4(56)(78))', 1, -1, 'i', 0);
 SELECT REGEXP_SUBSTR('1234567890 1234567890', '(123)(4(56)(78))', 1, 1, 'i', -1);
 
+----
+-- Tests for REGEXP_REPLACE()
+----
+
+-- ORACLE> SELECT REGEXP_REPLACE('512.123.4567', '([[:digit:]]{3})\.([[:digit:]]{3})\.([[:digit:]]{4})', '(\1) \2-\3') FROM DUAL; -> (512) 123-4567
+SELECT REGEXP_REPLACE('512.123.4567', '([[:digit:]]{3})\.([[:digit:]]{3})\.([[:digit:]]{4})', '(\1) \2-\3');
+-- ORACLE> SELECT REGEXP_REPLACE('512.123.4567 612.123.4567', '([[:digit:]]{3})\.([[:digit:]]{3})\.([[:digit:]]{4})', '(\1) \2-\3') FROM DUAL; -> (512) 123-4567 (612) 123-4567
+SELECT oracle.REGEXP_REPLACE('512.123.4567 612.123.4567', '([[:digit:]]{3})\.([[:digit:]]{3})\.([[:digit:]]{4})', '(\1) \2-\3');
+-- ORACLE> SELECT REGEXP_REPLACE('number   your     street,    zipcode  town, FR', '( ){2,}', ' ') FROM DUAL; -> number your street, zipcode town, FR
+SELECT oracle.REGEXP_REPLACE('number   your     street,    zipcode  town, FR', '( ){2,}', ' ');
+-- ORACLE> SELECT REGEXP_REPLACE('number   your     street,'||CHR(10)||'    zipcode  town, FR', '( ){2,}', ' ') FROM DUAL; -> number your street,
+-- zipcode town, FR
+SELECT oracle.REGEXP_REPLACE('number   your     street,'||CHR(10)||'    zipcode  town, FR', '( ){2,}', ' ');
+-- ORACLE> SELECT REGEXP_REPLACE('number   your     street,    zipcode  town, FR', '( ){2,}', ' ', 9) FROM DUAL; -> number    your street, zipcode town, FR
+SELECT oracle.REGEXP_REPLACE('number   your     street,    zipcode  town, FR', '( ){2,}', ' ', 9);
+-- ORACLE> SELECT REGEXP_REPLACE('number   your     street,    zipcode  town, FR', '( ){2,}', ' ', 9, 0) FROM DUAL; -> number    your street, zipcode town, FR
+SELECT oracle.REGEXP_REPLACE('number   your     street,    zipcode  town, FR', '( ){2,}', ' ', 9, 0);
+-- ORACLE> SELECT REGEXP_REPLACE('number   your     street,    zipcode  town, FR', '( ){2,}', ' ', 9, 2) FROM DUAL; -> number    your     street, zipcode  town, FR
+SELECT oracle.REGEXP_REPLACE('number   your     street,    zipcode  town, FR', '( ){2,}', ' ', 9, 2);
+-- ORACLE> SELECT REGEXP_REPLACE('number   your     street,    zipcode  town, FR', '( ){2,}', ' ', 9, 2, 'm') FROM DUAL; -> number    your     street, zipcode  town, FR
+SELECT oracle.REGEXP_REPLACE('number   your     street,    zipcode  town, FR', '( ){2,}', ' ', 9, 2, 'm');
+-- ORACLE> SELECT REGEXP_REPLACE('number   your     street,    zipcode  town, FR', '([EURT]){2,}', '[\1]', 9, 2, 'i') FROM DUAL; -> number    your     s[t],    zipcode  town, FR
+SELECT oracle.REGEXP_REPLACE('number   your     street,    zipcode  town, FR', '([EURT]){2,}', '[\1]', 9, 2, 'i');
+-- ORACLE> SELECT REGEXP_REPLACE('number   your     street,    zipcode  town, FR', '[ ]{2,}', ' ', 9, 2) FROM DUAL; -> number    your     street, zipcode  town, FR
+SELECT oracle.REGEXP_REPLACE('number   your     street,    zipcode  town, FR', '( ){2,}', ' ', 9, 2);
+
+-- ORACLE> SELECT REGEXP_REPLACE ('A PostgreSQL function', 'A|e|i|o|u', 'X', 1, 2) FROM DUAL; -> A PXstgreSQL function
+SELECT oracle.REGEXP_REPLACE ('A PostgreSQL function', 'A|e|i|o|u', 'X', 1, 2);
+-- ORACLE> SELECT REGEXP_REPLACE ('A PostgreSQL function', 'a|e|i|o|u', 'X', 1, 0, 'i') FROM DUAL; -> X PXstgrXSQL fXnctXXn
+SELECT oracle.REGEXP_REPLACE ('A PostgreSQL function', 'a|e|i|o|u', 'X', 1, 0, 'i');
+-- ORACLE> SELECT REGEXP_REPLACE ('A PostgreSQL function', 'a|e|i|o|u', 'X', 1, 1, 'i') FROM DUAL; -> X PostgreSQL function
+SELECT oracle.REGEXP_REPLACE ('A PostgreSQL function', 'a|e|i|o|u', 'X', 1, 1, 'i');
+-- ORACLE> SELECT REGEXP_REPLACE ('A PostgreSQL function', 'a|e|i|o|u', 'X', 1, 2, 'i') FROM DUAL; -> A PXstgreSQL function
+SELECT oracle.REGEXP_REPLACE ('A PostgreSQL function', 'a|e|i|o|u', 'X', 1, 2, 'i');
+-- ORACLE> SELECT REGEXP_REPLACE ('A PostgreSQL function', 'a|e|i|o|u', 'X', 1, 3, 'i') FROM DUAL; -> A PostgrXSQL function
+SELECT oracle.REGEXP_REPLACE ('A PostgreSQL function', 'a|e|i|o|u', 'X', 1, 3, 'i');
+-- ORACLE> SELECT REGEXP_REPLACE ('A PostgreSQL function', 'a|e|i|o|u', 'X', 1, 9, 'i') FROM DUAL; -> A PostgreSQL function
+SELECT oracle.REGEXP_REPLACE ('A PostgreSQL function', 'a|e|i|o|u', 'X', 1, 9, 'i');
+-- ORACLE> SELECT REGEXP_REPLACE ('A PostgreSQL function', 'A|e|i|o|u', 'X', 1, 9) FROM DUAL; -> A PostgreSQL function
+SELECT oracle.REGEXP_REPLACE ('A PostgreSQL function', 'A|e|i|o|u', 'X', 1, 9);
+-- ORACLE> SELECT REGEXP_REPLACE ('A PostgreSQL function', 'a|e|i|o|u', 'X', -1, 0, 'i') FROM DUAL; -> ORA-01428
+SELECT oracle.REGEXP_REPLACE ('A PostgreSQL function', 'a|e|i|o|u', 'X', -1, 0, 'i');
+-- ORACLE> SELECT REGEXP_REPLACE ('A PostgreSQL function', 'a|e|i|o|u', 'X', 1, -1, 'i') FROM DUAL; -> ORA-01428
+SELECT oracle.REGEXP_REPLACE ('A PostgreSQL function', 'a|e|i|o|u', 'X', 1, -1, 'i');
+-- ORACLE> SELECT REGEXP_REPLACE ('A PostgreSQL function', 'a|e|i|o|u', 'X', 1, 1, 'g') FROM DUAL; -> ORA-01760
+SELECT oracle.REGEXP_REPLACE ('A PostgreSQL function', 'a|e|i|o|u', 'X', 1, 1, 'g');
+


### PR DESCRIPTION
This function supports start position and occurrence in addition to the PostgreSQL regexp_replace() implementation.
It correspond to the Oracle behavior and consist in plpgsql functions based on PostgreSQL regexp_matches() and
regexp_replace(). All details of the implementation is explained in the documentation. Also include in this patch also
include regression tests for regexp_replace() including the Oracle queries and results in comment.

Add raise exception when regexp modifiers are not supported by the Oracle implementation. Supported flags are:

- 'i' specifies case-insensitive matching.
- 'c' specifies case-sensitive matching.
- 'n' allows the period (.) to match the newline character.
- 'm' treats the source string as multiple lines.
- 's' alias for 'm' used by DB2 implementation of the regexp function.
- 'x' ignores whitespace characters.