### PR TITLE
Implement function DBMS_UTILITY.GET_TIME the right way.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ OBJS= parse_keyword.o convert.o file.o datefce.o magic.o others.o plvstr.o plvda
 
 EXTENSION = orafce
 
-DATA = orafce--3.15.sql orafce--3.2--3.3.sql orafce--3.3--3.4.sql orafce--3.4--3.5.sql orafce--3.5--3.6.sql orafce--3.6--3.7.sql orafce--3.7--3.8.sql orafce--3.8--3.9.sql orafce--3.9--3.10.sql orafce--3.10--3.11.sql orafce--3.11--3.12.sql orafce--3.12--3.13.sql orafce--3.13--3.14.sql orafce--3.14--3.15.sql
+DATA = orafce--3.16.sql orafce--3.2--3.3.sql orafce--3.3--3.4.sql orafce--3.4--3.5.sql orafce--3.5--3.6.sql orafce--3.6--3.7.sql orafce--3.7--3.8.sql orafce--3.8--3.9.sql orafce--3.9--3.10.sql orafce--3.10--3.11.sql orafce--3.11--3.12.sql orafce--3.12--3.13.sql orafce--3.13--3.14.sql orafce--3.14--3.15.sql orafce--3.15--3.16.sql
 DOCS = README.asciidoc COPYRIGHT.orafce INSTALL.orafce
 
 PG_CONFIG ?= pg_config

--- a/doc/orafce_documentation/Orafce_Documentation_06.md
+++ b/doc/orafce_documentation/Orafce_Documentation_06.md
@@ -1483,6 +1483,7 @@ Provides utilities of PL/pgSQL.
 |Feature|Description|
 |:---|:---|
 |FORMAT_CALL_STACK|Returns the current call stack.|
+|GET_TIME|Returns the number of hundredths of seconds that have elapsed since a point in time in the past.|
 
 
 **Syntax**
@@ -1555,6 +1556,38 @@ SELECT dbms_utility2_exe();
 DROP FUNCTION dbms_utility2_exe();
 DROP FUNCTION dbms_utility1_exe();
 ~~~
+
+**GET_TIME**
+
+ - GET_TIME returns the current time in 100th's of a second from a point in time in the past. This function is used for determining elapsed time.
+
+**Example**
+
+----
+
+~~~
+DO $$
+DECLARE
+    start_time integer;
+    end_time integer;
+BEGIN
+    start_time := DBMS_UTILITY.GET_TIME;
+    PERFORM pg_sleep(10);
+    end_time := DBMS_UTILITY.GET_TIME;
+    RAISE NOTICE 'Execution time: % seconds', (end_time - start_time)/100;
+END
+$$;
+~~~
+
+----
+
+**Note**
+
+----
+
+The function is called twice, the first time at the beginning of some procedural code and the second time at end. Then the first (earlier) number is subtracted from the second (later) number to determine the time elapsed. Must be divided by 100 to report the number of seconds elapsed.
+
+----
 
 
 ### 6.7 UTL_FILE

--- a/expected/dbms_utility.out
+++ b/expected/dbms_utility.out
@@ -14,3 +14,4 @@ checkintunpaddedcallstack
 0,,anonymous object
 0,,checkintunpaddedcallstack
 (1 row)
+NOTICE:  Execution time: 2 seconds

--- a/orafce.control
+++ b/orafce.control
@@ -1,5 +1,5 @@
 # orafce extension
 comment = 'Functions and operators that emulate a subset of functions and packages from the Oracle RDBMS'
-default_version = '3.15'
+default_version = '3.16'
 module_pathname = '$libdir/orafce'
 relocatable = false

--- a/sql/dbms_utility.sql
+++ b/sql/dbms_utility.sql
@@ -61,3 +61,20 @@ DROP FUNCTION checkHexCallStack();
 DROP FUNCTION checkIntCallStack();
 DROP FUNCTION checkIntUnpaddedCallStack();
 
+/*
+ * Test for dbms_utility.get_time(), the result is rounded
+ * to have constant result in the regression test.
+ */
+DO $$
+DECLARE
+    start_time integer;
+    end_time integer;
+BEGIN
+    start_time := DBMS_UTILITY.GET_TIME();
+    PERFORM pg_sleep(2);
+    end_time := DBMS_UTILITY.GET_TIME();
+    RAISE NOTICE 'Execution time: % seconds', round((end_time - start_time)::numeric/100, 0);
+END
+$$;
+
+

--- a/utility.c
+++ b/utility.c
@@ -12,6 +12,9 @@
 
 */
 
+#include <time.h>
+#include <stdio.h>
+
 #include "postgres.h"
 #include "utils/builtins.h"
 #include "utils/numeric.h"
@@ -34,6 +37,7 @@
 
 PG_FUNCTION_INFO_V1(dbms_utility_format_call_stack0);
 PG_FUNCTION_INFO_V1(dbms_utility_format_call_stack1);
+PG_FUNCTION_INFO_V1(dbms_utility_get_time);
 
 static char*
 dbms_utility_format_call_stack(char mode)
@@ -207,4 +211,17 @@ dbms_utility_format_call_stack1(PG_FUNCTION_ARGS)
 	}
 
 	PG_RETURN_TEXT_P(cstring_to_text(dbms_utility_format_call_stack(mode)));
+}
+
+/*
+ * Returns the number of hundredths of seconds that have elapsed
+ * since a point in time in the past.
+ */
+Datum
+dbms_utility_get_time(PG_FUNCTION_ARGS)
+{
+	struct timeval tv;
+
+	gettimeofday(&tv,NULL);
+	PG_RETURN_INT32((int32) (tv.tv_sec*1000000+tv.tv_usec)/10000);
 }


### PR DESCRIPTION
Add DBMS_UTILITY.GET_TIME function, it returns the current time in
100th's of a second from a point in time in the past. This function
is used for determining elapsed time. This function is widely used
in some Oracle installation for timing of functions or statements.

Example of use:

	DO $$
	DECLARE
	    start_time integer;
	    end_time integer;
	BEGIN
	    start_time := DBMS_UTILITY.GET_TIME;
	    PERFORM pg_sleep(10);
	    end_time := DBMS_UTILITY.GET_TIME;
	    RAISE NOTICE 'Execution time: % seconds', (end_time - start_time)/100;
	END
	$$;

This function do not return the same value as the Oracle implementation
and the value is negative. But it is mainly used to get an elapsed time
between two execution of the function so this will give the right result.