### PR TITLE
Fix some errors when releasing resources

### DIFF
--- a/alert.c
+++ b/alert.c
@@ -598,6 +598,7 @@ dbms_alert_removeall(PG_FUNCTION_ARGS)
 	int cycle = 0;
 	float8 endtime;
 	float8 timeout = 2;
+	alert_lock *alck;
 
 	WATCH_PRE(timeout, endtime, cycle);
 	if (ora_lock_shmem(SHMEMMSGSZ, MAX_PIPES,MAX_EVENTS,MAX_LOCKS,false))
@@ -608,7 +609,8 @@ dbms_alert_removeall(PG_FUNCTION_ARGS)
 				find_and_remove_message_item(i, sid,
 								 false, true, true, NULL, NULL);
 				unregister_event(i, sid);
-
+				alck = find_lock(sid, false);
+				alck->sid = NOT_USED;
 			}
 		LWLockRelease(shmem_lockid);
 		PG_RETURN_VOID();

--- a/pipe.c
+++ b/pipe.c
@@ -579,6 +579,11 @@ remove_pipe(text *pipe_name, bool purge)
 		{
 			ora_sfree(p->pipe_name);
 			p->is_valid = false;
+			if (NULL != p->creator)
+			{
+				ora_sfree(p->creator);
+				p->creator = NULL;
+			}
 		}
 	}
 }


### PR DESCRIPTION
1) memory leak due to not freeing creator field of orafce_pipe structure
   when removing pipes
2) overflow of array of alert_lock structures