### PR TITLE
sql/dbms_utility.sql: Allow longer test runtime

### DIFF
--- a/sql/dbms_utility.sql
+++ b/sql/dbms_utility.sql
@@ -73,7 +73,7 @@ BEGIN
     start_time := DBMS_UTILITY.GET_TIME();
     PERFORM pg_sleep(2);
     end_time := DBMS_UTILITY.GET_TIME();
-    RAISE NOTICE 'Execution time: % seconds', round((end_time - start_time)::numeric/100, 0);
+    RAISE NOTICE 'Execution time: % seconds', trunc((end_time - start_time)::numeric/100);
 END
 $$;
 


### PR DESCRIPTION
round() rounds down only up to 2.49, but on some build machines the test
needs more time. Use trunc() instead for more legroom up to 2.99.