### PR TITLE
Remove duplicate variable declarations

### DIFF
--- a/orafce.h
+++ b/orafce.h
@@ -33,9 +33,6 @@ extern int ora_mb_strlen1(text *str);
 extern char *nls_date_format;
 extern char *orafce_timezone;
 
-extern char *nls_date_format;
-extern char *orafce_timezone;
-
 extern bool orafce_varchar2_null_safe_concat;
 
 /*


### PR DESCRIPTION
both nls_date_format and orafce_timezone are declared twice, so remove them.