### PR TITLE
This patch reproduce the same behavior of the regexp_* function with

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ OBJS= parse_keyword.o convert.o file.o datefce.o magic.o others.o plvstr.o plvda
 
 EXTENSION = orafce
 
-DATA = orafce--3.16.sql orafce--3.2--3.3.sql orafce--3.3--3.4.sql orafce--3.4--3.5.sql orafce--3.5--3.6.sql orafce--3.6--3.7.sql orafce--3.7--3.8.sql orafce--3.8--3.9.sql orafce--3.9--3.10.sql orafce--3.10--3.11.sql orafce--3.11--3.12.sql orafce--3.12--3.13.sql orafce--3.13--3.14.sql orafce--3.14--3.15.sql orafce--3.15--3.16.sql
+DATA = orafce--3.17.sql orafce--3.2--3.3.sql orafce--3.3--3.4.sql orafce--3.4--3.5.sql orafce--3.5--3.6.sql orafce--3.6--3.7.sql orafce--3.7--3.8.sql orafce--3.8--3.9.sql orafce--3.9--3.10.sql orafce--3.10--3.11.sql orafce--3.11--3.12.sql orafce--3.12--3.13.sql orafce--3.13--3.14.sql orafce--3.14--3.15.sql orafce--3.15--3.16.sql orafce--3.16--3.17.sql
 DOCS = README.asciidoc COPYRIGHT.orafce INSTALL.orafce
 
 PG_CONFIG ?= pg_config

--- a/expected/regexp_func.out
+++ b/expected/regexp_func.out
@@ -511,7 +511,7 @@ SELECT REGEXP_SUBSTR('number of your street, zipcode town, FR', ',\s+[Zf][^,]+',
 SELECT REGEXP_SUBSTR('number of your street, zipcode town, FR', ',\s+([Zf][^,]+)', 1, 1, 'i', 1);
  regexp_substr 
 ---------------
- 
+ zipcode town
 (1 row)
 
 -- ORACLE> SELECT REGEXP_SUBSTR('1234567890 1234567890', '(123)(4(56)(78))', 1, 1, 'i', 4) FROM DUAL; -> 78
@@ -675,3 +675,256 @@ ERROR:  argument 'occurrence' must be a positive number
 -- ORACLE> SELECT REGEXP_REPLACE ('A PostgreSQL function', 'a|e|i|o|u', 'X', 1, 1, 'g') FROM DUAL; -> ORA-01760
 SELECT oracle.REGEXP_REPLACE ('A PostgreSQL function', 'a|e|i|o|u', 'X', 1, 1, 'g');
 ERROR:  argument 'flags' has unsupported modifier(s).
+--
+-- Test NULL input in the regexp_* functions that must returned NULL except for the modifier
+-- or regexp flag. There is an exception with regexp_replace(), if the pattern is null (second
+-- parameter) the original string is returned. We don't test functions witht the STRICT attribute
+--
+SELECT oracle.REGEXP_LIKE(NULL, '\d+', 'i');
+ regexp_like 
+-------------
+ 
+(1 row)
+
+SELECT oracle.REGEXP_LIKE('1234', NULL, 'i');
+ regexp_like 
+-------------
+ 
+(1 row)
+
+SELECT oracle.REGEXP_LIKE('1234', '\d+', NULL);
+ regexp_like 
+-------------
+ t
+(1 row)
+
+SELECT oracle.REGEXP_LIKE('1234', '\d+', '');
+ regexp_like 
+-------------
+ t
+(1 row)
+
+SELECT oracle.REGEXP_COUNT('1234', '\d', NULL) ;
+ regexp_count 
+--------------
+             
+(1 row)
+
+SELECT oracle.REGEXP_COUNT('1234', '\d', 1, NULL) ;
+ regexp_count 
+--------------
+            4
+(1 row)
+
+SELECT oracle.REGEXP_COUNT('1234', '\d', 1, '') ;
+ regexp_count 
+--------------
+            4
+(1 row)
+
+SELECT oracle.REGEXP_COUNT('1234', '\d', NULL, NULL) ;
+ regexp_count 
+--------------
+             
+(1 row)
+
+SELECT oracle.REGEXP_COUNT(NULL, '4', 1, 'i');
+ regexp_count 
+--------------
+             
+(1 row)
+
+SELECT oracle.REGEXP_INSTR('1234', '4', NULL);
+ regexp_instr 
+--------------
+             
+(1 row)
+
+SELECT oracle.REGEXP_INSTR('1234', '4', 1, NULL);
+ regexp_instr 
+--------------
+             
+(1 row)
+
+SELECT oracle.REGEXP_INSTR('1234', '4', 1, 1, NULL);
+ regexp_instr 
+--------------
+             
+(1 row)
+
+SELECT oracle.REGEXP_INSTR('1234', '4', 1, 1, 1, NULL);
+ regexp_instr 
+--------------
+            5
+(1 row)
+
+SELECT oracle.REGEXP_INSTR('1234', '4', 1, 1, 0, NULL);
+ regexp_instr 
+--------------
+            4
+(1 row)
+
+SELECT oracle.REGEXP_INSTR('1234', '4', 1, 1, 0, 'i', NULL);
+ regexp_instr 
+--------------
+             
+(1 row)
+
+SELECT oracle.REGEXP_INSTR('1234', '4', 1, 1, 0, '', NULL);
+ regexp_instr 
+--------------
+             
+(1 row)
+
+SELECT oracle.REGEXP_INSTR(NULL, '4', 1, 1, 0, 'i', 2);
+ regexp_instr 
+--------------
+             
+(1 row)
+
+SELECT oracle.REGEXP_INSTR(NULL, '4', 1, 1, 0, 'i', 2);
+ regexp_instr 
+--------------
+             
+(1 row)
+
+SELECT oracle.REGEXP_SUBSTR('1234', '1(.*)', null);
+ regexp_substr 
+---------------
+ 
+(1 row)
+
+SELECT oracle.REGEXP_SUBSTR('1234', '234', 1, null);
+ regexp_substr 
+---------------
+ 
+(1 row)
+
+SELECT oracle.REGEXP_SUBSTR('1234', '234', 1, 1, null);
+ regexp_substr 
+---------------
+ 234
+(1 row)
+
+SELECT oracle.REGEXP_SUBSTR('1234', '234', 1, 1, '');
+ regexp_substr 
+---------------
+ 234
+(1 row)
+
+SELECT oracle.REGEXP_SUBSTR('1234', '234', 1, 1, 'i', null);
+ regexp_substr 
+---------------
+ 
+(1 row)
+
+-- test for capture group
+SELECT oracle.REGEXP_SUBSTR('1234', '2(3)(4)', 1, 1, 'i', 1);
+ regexp_substr 
+---------------
+ 3
+(1 row)
+
+SELECT oracle.REGEXP_SUBSTR('1234', '2(3)(4)', 1, 1, 'i', 2);
+ regexp_substr 
+---------------
+ 4
+(1 row)
+
+SELECT oracle.REGEXP_SUBSTR('1234', '2(3)(4)', 1, 1, 'i', 0);
+ regexp_substr 
+---------------
+ 234
+(1 row)
+
+-- Special case for second parameter in REGEXP_REPLACE, when null returns the original value.
+SELECT oracle.REGEXP_REPLACE(null, '\d', 'a');
+ regexp_replace 
+----------------
+ 
+(1 row)
+
+SELECT oracle.REGEXP_REPLACE('1234', null, 'a');
+ regexp_replace 
+----------------
+ 1234
+(1 row)
+
+SELECT oracle.REGEXP_REPLACE('1234', null, null);
+ regexp_replace 
+----------------
+ 1234
+(1 row)
+
+SELECT oracle.REGEXP_REPLACE('1234', '\d', null);
+ regexp_replace 
+----------------
+ 
+(1 row)
+
+SELECT oracle.REGEXP_REPLACE('1234', '\d', 'a', null);
+ regexp_replace 
+----------------
+ 
+(1 row)
+
+SELECT oracle.REGEXP_REPLACE('1234', null, 'a', 2);
+ regexp_replace 
+----------------
+ 1234
+(1 row)
+
+SELECT oracle.REGEXP_REPLACE('1234', null, 'a', null);
+ regexp_replace 
+----------------
+ 
+(1 row)
+
+SELECT oracle.REGEXP_REPLACE('1234', null, 'a', 1);
+ regexp_replace 
+----------------
+ 1234
+(1 row)
+
+SELECT oracle.REGEXP_REPLACE('1234', null, 'a', 1, null);
+ regexp_replace 
+----------------
+ 
+(1 row)
+
+SELECT oracle.REGEXP_REPLACE('1234', '\d', 'a', 1, null);
+ regexp_replace 
+----------------
+ 
+(1 row)
+
+SELECT oracle.REGEXP_REPLACE('1234', '\d', 'a', 1, null);
+ regexp_replace 
+----------------
+ 
+(1 row)
+
+SELECT oracle.REGEXP_REPLACE('1234', '\d', 'a', 1, null);
+ regexp_replace 
+----------------
+ 
+(1 row)
+
+SELECT oracle.REGEXP_REPLACE('1234', '\d', 'a', 1, 1, null);
+ regexp_replace 
+----------------
+ a234
+(1 row)
+
+SELECT oracle.REGEXP_REPLACE('1234', '\d', 'a', 1, NULL, 'i');
+ regexp_replace 
+----------------
+ 
+(1 row)
+
+SELECT oracle.REGEXP_REPLACE('1234', null, 'a', 1, 1, 'i');
+ regexp_replace 
+----------------
+ 1234
+(1 row)
+

--- a/orafce--3.16--3.17.sql
+++ b/orafce--3.16--3.17.sql
@@ -1,0 +1,685 @@
+-- Translate Oracle regexp modifier into PostgreSQl ones
+-- Append the global modifier if $2 is true. Used internally
+-- by regexp_*() functions bellow.
+CREATE OR REPLACE FUNCTION oracle.translate_oracle_modifiers(text, bool)
+RETURNS text
+AS $$
+DECLARE
+  modifiers text := '';
+BEGIN
+  IF $1 IS NOT NULL THEN
+    -- Check that we don't have modifier not supported by Oracle
+    IF $1 ~ '[^icnsmx]' THEN
+      -- Modifier 's' is not supported by Oracle but it is a synonym
+      -- of 'n', we translate 'n' into 's' bellow. It is safe to allow it.
+      RAISE EXCEPTION 'argument ''flags'' has unsupported modifier(s).';
+    END IF;
+    -- Oracle 'n' modifier correspond to 's' POSIX modifier
+    -- Oracle 'm' modifier correspond to 'n' POSIX modifier
+    modifiers := translate($1, 'nm', 'sn');
+  END IF;
+  IF $2 THEN
+    modifiers := modifiers || 'g';
+  END IF;
+  RETURN modifiers;
+END;
+$$
+LANGUAGE plpgsql;
+
+-- REGEXP_LIKE( string text, pattern text) -> boolean
+-- If one of the param is NULL returns NULL, declared STRICT
+CREATE OR REPLACE FUNCTION oracle.regexp_like(text, text)
+RETURNS boolean
+AS $$
+  -- Oracle default behavior is newline-sensitive,
+  -- PostgreSQL not, so force 'p' modifier to affect
+  -- newline-sensitivity but not ^ and $ search.
+  SELECT CASE WHEN (count(*) > 0) THEN true ELSE false END FROM regexp_matches($1, $2, 'p');
+$$
+LANGUAGE 'sql' STRICT;
+
+-- REGEXP_LIKE( string text, pattern text, flags text ) -> boolean
+CREATE OR REPLACE FUNCTION oracle.regexp_like(text, text, text)
+RETURNS boolean
+AS $$
+DECLARE
+  modifiers text;
+BEGIN
+  -- Only modifier can be NULL
+  IF $1 IS NULL OR $2 IS NULL THEN
+    RETURN NULL;
+  END IF;
+  modifiers := oracle.translate_oracle_modifiers($3, false);
+  IF (regexp_matches($1, $2, modifiers))[1] IS NOT NULL THEN
+    RETURN true;
+  END IF;
+  RETURN false;
+END;
+$$
+LANGUAGE plpgsql;
+
+-- REGEXP_COUNT( string text, pattern text ) -> integer
+CREATE OR REPLACE FUNCTION oracle.regexp_count(text, text)
+RETURNS integer
+AS $$
+  -- Oracle default behavior is newline-sensitive,
+  -- PostgreSQL not, so force 'p' modifier to affect
+  -- newline-sensitivity but not ^ and $ search.
+  SELECT count(*)::integer FROM regexp_matches($1, $2, 'pg');
+$$
+LANGUAGE 'sql' STRICT;
+
+-- REGEXP_COUNT( string text, pattern text, position int ) -> integer
+CREATE OR REPLACE FUNCTION oracle.regexp_count(text, text, integer)
+RETURNS integer
+AS $$
+DECLARE
+  v_cnt integer;
+BEGIN
+  -- Check numeric arguments
+  IF $3 < 1 THEN
+    RAISE EXCEPTION 'argument ''position'' must be a number greater than 0';
+  END IF;
+
+  -- Oracle default behavior is newline-sensitive,
+  -- PostgreSQL not, so force 'p' modifier to affect
+  -- newline-sensitivity but not ^ and $ search.
+  v_cnt :=  (SELECT count(*)::integer FROM regexp_matches(substr($1, $3), $2, 'pg'));
+  RETURN v_cnt;
+END;
+$$
+LANGUAGE plpgsql STRICT;
+
+-- REGEXP_COUNT( string text, pattern text, position int, flags text ) -> integer
+CREATE OR REPLACE FUNCTION oracle.regexp_count(text, text, integer, text)
+RETURNS integer
+AS $$
+DECLARE
+  modifiers text;
+  v_cnt   integer;
+BEGIN
+  -- Only modifier can be NULL
+  IF $1 IS NULL OR $2 IS NULL OR $3 IS NULL THEN
+    RETURN NULL;
+  END IF;
+  -- Check numeric arguments
+  IF $3 < 1 THEN
+    RAISE EXCEPTION 'argument ''position'' must be a number greater than 0';
+  END IF;
+
+  modifiers := oracle.translate_oracle_modifiers($4, true);
+  v_cnt := (SELECT count(*)::integer FROM regexp_matches(substr($1, $3), $2, modifiers));
+  RETURN v_cnt;
+END;
+$$
+LANGUAGE plpgsql;
+
+--  REGEXP_INSTR( string text, pattern text ) -> integer
+CREATE OR REPLACE FUNCTION oracle.regexp_instr(text, text)
+RETURNS integer
+AS $$
+DECLARE
+  v_pos integer;
+  v_pattern text;
+BEGIN
+  -- Without subexpression specified, assume 0 which mean that the first
+  -- position for the substring matching the whole pattern is returned.
+  -- We need to enclose the pattern between parentheses.
+  v_pattern := '(' || $2 || ')';
+
+  -- Oracle default behavior is newline-sensitive,
+  -- PostgreSQL not, so force 'p' modifier to affect
+  -- newline-sensitivity but not ^ and $ search.
+  v_pos := (SELECT position((SELECT (regexp_matches($1, v_pattern, 'pg'))[1] OFFSET 0 LIMIT 1) IN $1));
+
+  -- position() returns NULL when not found, we need to return 0 instead
+  IF v_pos IS NOT NULL THEN
+    RETURN v_pos;
+  END IF;
+  RETURN 0;
+END;
+$$
+LANGUAGE plpgsql STRICT;
+
+--  REGEXP_INSTR( string text, pattern text, position int ) -> integer
+CREATE OR REPLACE FUNCTION oracle.regexp_instr(text, text, integer)
+RETURNS integer
+AS $$
+DECLARE
+  v_pos integer;
+  v_pattern text;
+BEGIN
+  IF $3 < 1 THEN
+    RAISE EXCEPTION 'argument ''position'' must be a number greater than 0';
+  END IF;
+  -- Without subexpression specified, assume 0 which mean that the first
+  -- position for the substring matching the whole pattern is returned.
+  -- We need to enclose the pattern between parentheses.
+  v_pattern := '(' || $2 || ')';
+
+  -- Oracle default behavior is newline-sensitive,
+  -- PostgreSQL not, so force 'p' modifier to affect
+  -- newline-sensitivity but not ^ and $ search.
+  v_pos := (SELECT position((SELECT (regexp_matches(substr($1, $3), v_pattern, 'pg'))[1] OFFSET 0 LIMIT 1) IN $1));
+
+  -- position() returns NULL when not found, we need to return 0 instead
+  IF v_pos IS NOT NULL THEN
+    RETURN v_pos;
+  END IF;
+  RETURN 0;
+END;
+$$
+LANGUAGE plpgsql STRICT;
+
+--  REGEXP_INSTR( string text, pattern text, position int, occurence int ) -> integer
+CREATE OR REPLACE FUNCTION oracle.regexp_instr(text, text, integer, integer)
+RETURNS integer
+AS $$
+DECLARE
+  v_pos integer;
+  v_pattern text;
+BEGIN
+  IF $3 < 1 THEN
+    RAISE EXCEPTION 'argument ''position'' must be a number greater than 0';
+  END IF;
+  IF $4 < 1 THEN
+    RAISE EXCEPTION 'argument ''occurence'' must be a number greater than 0';
+  END IF;
+
+  -- Without subexpression specified, assume 0 which mean that the first
+  -- position for the substring matching the whole pattern is returned.
+  -- We need to enclose the pattern between parentheses.
+  v_pattern := '(' || $2 || ')';
+
+  -- Oracle default behavior is newline-sensitive,
+  -- PostgreSQL not, so force 'p' modifier to affect
+  -- newline-sensitivity but not ^ and $ search.
+  v_pos := (SELECT position((SELECT (regexp_matches(substr($1, $3), v_pattern, 'pg'))[1] OFFSET $4 - 1 LIMIT 1) IN $1));
+
+  -- position() returns NULL when not found, we need to return 0 instead
+  IF v_pos IS NOT NULL THEN
+    RETURN v_pos;
+  END IF;
+  RETURN 0;
+END;
+$$
+LANGUAGE plpgsql STRICT;
+
+--  REGEXP_INSTR( string text, pattern text, position int, occurence int, return_opt int ) -> integer
+CREATE OR REPLACE FUNCTION oracle.regexp_instr(text, text, integer, integer, integer)
+RETURNS integer
+AS $$
+DECLARE
+  v_pos integer;
+  v_len integer;
+  v_pattern text;
+BEGIN
+  IF $3 < 1 THEN
+    RAISE EXCEPTION 'argument ''position'' must be a number greater than 0';
+  END IF;
+  IF $4 < 1 THEN
+    RAISE EXCEPTION 'argument ''occurence'' must be a number greater than 0';
+  END IF;
+  IF $5 != 0 AND $5 != 1 THEN
+    RAISE EXCEPTION 'argument ''return_opt'' must be 0 or 1';
+  END IF;
+
+  -- Without subexpression specified, assume 0 which mean that the first
+  -- Without subexpression specified, assume 0 which mean that the first
+  -- position for the substring matching the whole pattern is returned.
+  -- We need to enclose the pattern between parentheses.
+  v_pattern := '(' || $2 || ')';
+
+  -- Oracle default behavior is newline-sensitive,
+  -- PostgreSQL not, so force 'p' modifier to affect
+  -- newline-sensitivity but not ^ and $ search.
+  v_pos := (SELECT position((SELECT (regexp_matches(substr($1, $3), v_pattern, 'pg'))[1] OFFSET $4-1 LIMIT 1) IN $1));
+
+  -- position() returns NULL when not found, we need to return 0 instead
+  IF v_pos IS NOT NULL THEN
+    IF $5 = 1 THEN
+      v_len := (SELECT length((SELECT (regexp_matches(substr($1, $3), v_pattern, 'pg'))[1] OFFSET $4 - 1 LIMIT 1)));
+      v_pos := v_pos + v_len;
+    END IF;
+    RETURN v_pos;
+  END IF;
+  RETURN 0;
+END;
+$$
+LANGUAGE plpgsql STRICT;
+
+--  REGEXP_INSTR( string text, pattern text, position int, occurence int, return_opt int, flags text ) -> integer
+CREATE OR REPLACE FUNCTION oracle.regexp_instr(text, text, integer, integer, integer, text)
+RETURNS integer
+AS $$
+DECLARE
+  v_pos integer;
+  v_len integer;
+  modifiers text;
+  v_pattern text;
+BEGIN
+  -- Only modifier can be NULL
+  IF $1 IS NULL OR $2 IS NULL OR $3 IS NULL OR $4 IS NULL OR $5 IS NULL THEN
+    RETURN NULL;
+  END IF;
+  -- Check numeric arguments
+  IF $3 < 1 THEN
+    RAISE EXCEPTION 'argument ''position'' must be a number greater than 0';
+  END IF;
+  IF $4 < 1 THEN
+      RAISE EXCEPTION 'argument ''occurence'' must be a number greater than 0';
+  END IF;
+  IF $5 != 0 AND $5 != 1 THEN
+    RAISE EXCEPTION 'argument ''return_opt'' must be 0 or 1';
+  END IF;
+  modifiers := oracle.translate_oracle_modifiers($6, true);
+
+  -- Without subexpression specified, assume 0 which mean that the first
+  -- position for the substring matching the whole pattern is returned.
+  -- We need to enclose the pattern between parentheses.
+  v_pattern := '(' || $2 || ')';
+  v_pos := (SELECT position((SELECT (regexp_matches(substr($1, $3), v_pattern, modifiers))[1] OFFSET $4 - 1 LIMIT 1) IN $1));
+
+  -- position() returns NULL when not found, we need to return 0 instead
+  IF v_pos IS NOT NULL THEN
+    IF $5 = 1 THEN
+      v_len := (SELECT length((SELECT (regexp_matches(substr($1, $3), v_pattern, modifiers))[1] OFFSET $4-1 LIMIT 1)));
+      v_pos := v_pos + v_len;
+    END IF;
+    RETURN v_pos;
+  END IF;
+  RETURN 0;
+END;
+$$
+LANGUAGE plpgsql;
+
+--  REGEXP_INSTR( string text, pattern text, position int, occurence int, return_opt int, flags text, group int ) -> integer
+CREATE OR REPLACE FUNCTION oracle.regexp_instr(text, text, integer, integer, integer, text, integer)
+RETURNS integer
+AS $$
+DECLARE
+  v_pos integer := 0;
+  v_pos_orig integer := $3;
+  v_len integer := 0;
+  modifiers text;
+  occurrence integer := $4;
+  idx integer := 1;
+  v_curr_pos integer := 0;
+  v_pattern text;
+  v_subexpr integer := $7;
+BEGIN
+  -- Only modifier can be NULL
+  IF $1 IS NULL OR $2 IS NULL OR $3 IS NULL OR $4 IS NULL OR $5 IS NULL OR $7 IS NULL THEN
+    RETURN NULL;
+  END IF;
+  -- Check numeric arguments
+  IF $3 < 1 THEN
+      RAISE EXCEPTION 'argument ''position'' must be a number greater than 0';
+  END IF;
+  IF $4 < 1 THEN
+    RAISE EXCEPTION 'argument ''occurence'' must be a number greater than 0';
+  END IF;
+  IF $7 < 0 THEN
+    RAISE EXCEPTION 'argument ''group'' must be a positive number';
+  END IF;
+  IF $5 != 0 AND $5 != 1 THEN
+    RAISE EXCEPTION 'argument ''return_opt'' must be 0 or 1';
+  END IF;
+
+  -- Translate Oracle regexp modifier into PostgreSQl ones
+  modifiers := oracle.translate_oracle_modifiers($6, true);
+
+  -- If subexpression value is 0 we need to enclose the pattern between parentheses.
+  IF v_subexpr = 0 THEN
+     v_pattern := '(' || $2 || ')';
+     v_subexpr := 1;
+  ELSE
+     v_pattern := $2;
+  END IF;
+
+  -- To get position of occurrence > 1 we need a more complex code
+  LOOP
+    v_curr_pos := v_curr_pos + v_len;
+    v_pos := (SELECT position((SELECT (regexp_matches(substr($1, v_pos_orig), '('||$2||')', modifiers))[1] OFFSET 0 LIMIT 1) IN substr($1, v_pos_orig)));
+    v_len := (SELECT length((SELECT (regexp_matches(substr($1, v_pos_orig), '('||$2||')', modifiers))[1] OFFSET 0 LIMIT 1)));
+
+    EXIT WHEN v_len IS NULL;
+
+    v_pos_orig := v_pos_orig + v_pos + v_len;
+    v_curr_pos := v_curr_pos + v_pos;
+    idx := idx + 1;
+
+    EXIT WHEN idx > occurrence;
+  END LOOP;
+
+  v_pos := (SELECT position((SELECT (regexp_matches(substr($1, v_curr_pos), v_pattern, modifiers))[v_subexpr] OFFSET 0 LIMIT 1) IN substr($1, v_curr_pos)));
+  IF v_pos IS NOT NULL THEN
+    IF $5 = 1 THEN
+      v_len := (SELECT length((SELECT (regexp_matches(substr($1, v_curr_pos), v_pattern, modifiers))[v_subexpr] OFFSET 0 LIMIT 1)));
+      v_pos := v_pos + v_len;
+    END IF;
+    RETURN v_pos + v_curr_pos - 1;
+  END IF;
+  RETURN 0;
+END;
+$$
+LANGUAGE plpgsql;
+
+-- REGEXP_SUBSTR( string text, pattern text ) -> text
+CREATE OR REPLACE FUNCTION oracle.regexp_substr(text, text)
+RETURNS text
+AS $$
+DECLARE
+  v_substr text;
+  v_pattern text;
+BEGIN
+  -- Without subexpression specified, assume 0 which mean that the first
+  -- position for the substring matching the whole pattern is returned.
+  -- We need to enclose the pattern between parentheses.
+  v_pattern := '(' || $2 || ')';
+
+  -- Oracle default behavior is newline-sensitive,
+  -- PostgreSQL not, so force 'p' modifier to affect
+  -- newline-sensitivity but not ^ and $ search.
+  v_substr := (SELECT (regexp_matches($1, v_pattern, 'pg'))[1] OFFSET 0 LIMIT 1);
+  RETURN v_substr;
+END;
+$$
+LANGUAGE plpgsql STRICT;
+
+-- REGEXP_SUBSTR( string text, pattern text, position int ) -> text
+CREATE OR REPLACE FUNCTION oracle.regexp_substr(text, text, int)
+RETURNS text
+AS $$
+DECLARE
+  v_substr text;
+  v_pattern text;
+BEGIN
+  -- Check numeric arguments
+  IF $3 < 1 THEN
+    RAISE EXCEPTION 'argument ''position'' must be a number greater than 0';
+  END IF;
+
+  -- Without subexpression specified, assume 0 which mean that the first
+  -- position for the substring matching the whole pattern is returned.
+  -- We need to enclose the pattern between parentheses.
+  v_pattern := '(' || $2 || ')';
+
+  -- Oracle default behavior is newline-sensitive,
+  -- PostgreSQL not, so force 'p' modifier to affect
+  -- newline-sensitivity but not ^ and $ search.
+  v_substr := (SELECT (regexp_matches(substr($1, $3), v_pattern, 'pg'))[1] OFFSET 0 LIMIT 1);
+  RETURN v_substr;
+END;
+$$
+LANGUAGE plpgsql STRICT;
+
+-- REGEXP_SUBSTR( string text, pattern text, position int, occurence int ) -> text
+CREATE OR REPLACE FUNCTION oracle.regexp_substr(text, text, integer, integer)
+RETURNS text
+AS $$
+DECLARE
+  v_substr text;
+  v_pattern text;
+BEGIN
+  -- Check numeric arguments
+  IF $3 < 1 THEN
+    RAISE EXCEPTION 'argument ''position'' must be a number greater than 0';
+  END IF;
+  IF $4 < 1 THEN
+    RAISE EXCEPTION 'argument ''occurence'' must be a number greater than 0';
+  END IF;
+
+  -- Without subexpression specified, assume 0 which mean that the first
+  -- position for the substring matching the whole pattern is returned.
+  -- We need to enclose the pattern between parentheses.
+  v_pattern := '(' || $2 || ')';
+
+  -- Oracle default behavior is newline-sensitive,
+  -- PostgreSQL not, so force 'p' modifier to affect
+  -- newline-sensitivity but not ^ and $ search.
+  v_substr := (SELECT (regexp_matches(substr($1, $3), v_pattern, 'pg'))[1] OFFSET $4 - 1 LIMIT 1);
+  RETURN v_substr;
+END;
+$$
+LANGUAGE plpgsql STRICT;
+
+-- REGEXP_SUBSTR( string text, pattern text, position int, occurence int, flags text ) -> text
+CREATE OR REPLACE FUNCTION oracle.regexp_substr(text, text, integer, integer, text)
+RETURNS text
+AS $$
+DECLARE
+  v_substr text;
+  v_pattern text;
+  modifiers text;
+BEGIN
+  -- Only modifier can be NULL
+  IF $1 IS NULL OR $2 IS NULL OR $3 IS NULL OR $4 IS NULL THEN
+    RETURN NULL;
+  END IF;
+  -- Check numeric arguments
+  IF $3 < 1 THEN
+    RAISE EXCEPTION 'argument ''position'' must be a number greater than 0';
+  END IF;
+  IF $4 < 1 THEN
+    RAISE EXCEPTION 'argument ''occurence'' must be a number greater than 0';
+  END IF;
+
+  modifiers := oracle.translate_oracle_modifiers($5, true);
+
+  -- Without subexpression specified, assume 0 which mean that the first
+  -- position for the substring matching the whole pattern is returned.
+  -- We need to enclose the pattern between parentheses.
+  v_pattern := '(' || $2 || ')';
+
+  -- Oracle default behavior is newline-sensitive,
+  -- PostgreSQL not, so force 'p' modifier to affect
+  -- newline-sensitivity but not ^ and $ search.
+  v_substr := (SELECT (regexp_matches(substr($1, $3), v_pattern, modifiers))[1] OFFSET $4 - 1 LIMIT 1);
+  RETURN v_substr;
+END;
+$$
+LANGUAGE plpgsql;
+
+-- REGEXP_SUBSTR( string text, pattern text, position int, occurence int, flags text, group int ) -> text
+CREATE OR REPLACE FUNCTION oracle.regexp_substr(text, text, integer, integer, text, int)
+RETURNS text
+AS $$
+DECLARE
+  v_substr text;
+  v_pattern text;
+  modifiers text;
+  v_subexpr integer := $6;
+  has_group integer;
+BEGIN
+  -- Only modifier can be NULL
+  IF $1 IS NULL OR $2 IS NULL OR $3 IS NULL OR $4 IS NULL OR $6 IS NULL THEN
+    RETURN NULL;
+  END IF;
+  -- Check numeric arguments
+  IF $3 < 1 THEN
+    RAISE EXCEPTION 'argument ''position'' must be a number greater than 0';
+  END IF;
+  IF $4 < 1 THEN
+    RAISE EXCEPTION 'argument ''occurence'' must be a number greater than 0';
+  END IF;
+  IF v_subexpr < 0 THEN
+    RAISE EXCEPTION 'argument ''group'' must be a positive number';
+  END IF;
+
+  -- Check that with v_subexpr = 1 we have a capture group otherwise return NULL
+  has_group := (SELECT count(*) FROM regexp_matches($2, '(?:[^\\]|^)\(', 'g'));
+  IF $6 = 1 AND has_group = 0 THEN
+    RETURN NULL;
+  END IF;
+
+  modifiers := oracle.translate_oracle_modifiers($5, true);
+
+  -- If subexpression value is 0 we need to enclose the pattern between parentheses.
+  IF v_subexpr = 0 THEN
+    v_pattern := '(' || $2 || ')';
+    v_subexpr := 1;
+  ELSE
+    v_pattern := $2;
+  END IF;
+
+  -- Oracle default behavior is newline-sensitive,
+  -- PostgreSQL not, so force 'p' modifier to affect
+  -- newline-sensitivity but not ^ and $ search.
+  v_substr := (SELECT (regexp_matches(substr($1, $3), v_pattern, modifiers))[v_subexpr] OFFSET $4 - 1 LIMIT 1);
+  RETURN v_substr;
+END;
+$$
+LANGUAGE plpgsql;
+
+-- REGEXP_REPLACE( string text, pattern text, replace_string text ) -> text
+CREATE OR REPLACE FUNCTION oracle.regexp_replace(text, text, text)
+RETURNS text
+AS $$
+DECLARE
+  str text;
+BEGIN
+  IF $2 IS NULL AND $1 IS NOT NULL THEN
+    RETURN $1;
+  END IF;
+  -- Oracle default behavior is to replace all occurence
+  -- whereas PostgreSQL only replace the first occurrence
+  -- so we need to add 'g' modifier.
+  SELECT pg_catalog.regexp_replace($1, $2, $3, 'g') INTO str;
+  RETURN str;
+END;
+$$
+LANGUAGE plpgsql;
+
+-- REGEXP_REPLACE( string text, pattern text, replace_string text, position int ) -> text
+CREATE OR REPLACE FUNCTION oracle.regexp_replace(text, text, text, integer)
+RETURNS text
+AS $$
+DECLARE
+  v_replaced_str text;
+  v_before text;
+BEGIN
+  IF $1 IS NULL OR $3 IS NULL OR $4 IS NULL THEN
+    RETURN NULL;
+  END IF;
+  IF $2 IS NULL THEN
+    RETURN $1;
+  END IF;
+  -- Check numeric arguments
+  IF $4 < 1 THEN
+    RAISE EXCEPTION 'argument ''position'' must be a number greater than 0';
+  END IF;
+
+  v_before = substr($1, 1, $4 - 1);
+
+  -- Oracle default behavior is to replace all occurence
+  -- whereas PostgreSQL only replace the first occurrence
+  -- so we need to add 'g' modifier.
+  v_replaced_str := v_before || pg_catalog.regexp_replace(substr($1, $4), $2, $3, 'g');
+  RETURN v_replaced_str;
+END;
+$$
+LANGUAGE plpgsql;
+
+-- REGEXP_REPLACE( string text, pattern text, replace_string text, position int, occurence int ) -> text
+CREATE OR REPLACE FUNCTION oracle.regexp_replace(text, text, text, integer, integer)
+RETURNS text
+AS $$
+DECLARE
+  v_replaced_str text;
+  v_pos integer := $4;
+  v_before text := '';
+  v_nummatch integer;
+BEGIN
+  IF $1 IS NULL OR $3 IS NULL OR $4 IS NULL OR $5 IS NULL THEN
+    RETURN NULL;
+  END IF;
+  IF $2 IS NULL THEN
+    RETURN $1;
+  END IF;
+  -- Check numeric arguments
+  IF $4 < 1 THEN
+    RAISE EXCEPTION 'argument ''position'' must be a number greater than 0';
+  END IF;
+  IF $5 < 0 THEN
+    RAISE EXCEPTION 'argument ''occurrence'' must be a positive number';
+  END IF;
+  -- Check if the occurrence queried exceeds the number of occurrences
+  IF $5 > 1 THEN
+    v_nummatch := (SELECT count(*) FROM regexp_matches(substr($1, $4), $2, 'g'));
+    IF $5 > v_nummatch THEN
+      RETURN $1;
+    END IF;
+    -- Get the position of the occurrence we are looking for
+    v_pos := oracle.regexp_instr($1, $2, $4, $5, 0, '', 1);
+    IF v_pos = 0 THEN
+      RETURN $1;
+    END IF;
+  END IF;
+  -- Get the substring before this position we will need to restore it
+  v_before := substr($1, 1, v_pos - 1);
+
+  -- Replace all occurrences
+  IF $5 = 0 THEN
+    v_replaced_str := v_before || pg_catalog.regexp_replace(substr($1, v_pos), $2, $3, 'g');
+  ELSE
+    -- Replace the first occurrence
+    v_replaced_str := v_before || pg_catalog.regexp_replace(substr($1, v_pos), $2, $3);
+  END IF;
+
+  RETURN v_replaced_str;
+END;
+$$
+LANGUAGE plpgsql;
+
+-- REGEXP_REPLACE( string text, pattern text, replace_string text, position int, occurence int, flags text ) -> text
+CREATE OR REPLACE FUNCTION oracle.regexp_replace(text, text, text, integer, integer, text)
+RETURNS text
+AS $$
+DECLARE
+  v_replaced_str text;
+  v_pos integer := $4;
+  v_nummatch integer;
+  v_before text := '';
+  modifiers text := '';
+BEGIN
+  IF $1 IS NULL OR $3 IS NULL OR $4 IS NULL OR $5 IS NULL THEN
+    RETURN NULL;
+  END IF;
+  IF $2 IS NULL THEN
+    RETURN $1;
+  END IF;
+  -- Check numeric arguments
+  IF $4 < 1 THEN
+    RAISE EXCEPTION 'argument ''position'' must be a number greater than 0';
+  END IF;
+  IF $5 < 0 THEN
+    RAISE EXCEPTION 'argument ''occurrence'' must be a positive number';
+  END IF;
+  -- Set the modifiers
+  IF $5 = 0 THEN
+    modifiers := oracle.translate_oracle_modifiers($6, true);
+  ELSE
+    modifiers := oracle.translate_oracle_modifiers($6, false);
+  END IF;
+  -- Check if the occurrence queried exceeds the number of occurrences
+  IF $5 > 1 THEN
+    v_nummatch := (SELECT count(*) FROM regexp_matches(substr($1, $4), $2, $6||'g'));
+    IF $5 > v_nummatch THEN
+      RETURN $1;
+    END IF;
+    -- Get the position of the occurrence we are looking for
+    v_pos := oracle.regexp_instr($1, $2, $4, $5, 0, $6, 1);
+    IF v_pos = 0 THEN
+      RETURN $1;
+    END IF;
+  END IF;
+  -- Get the substring before this position we will need to restore it
+  v_before := substr($1, 1, v_pos - 1);
+  -- Replace occurrence(s)
+  v_replaced_str := v_before || pg_catalog.regexp_replace(substr($1, v_pos), $2, $3, modifiers);
+  RETURN v_replaced_str;
+END;
+$$
+LANGUAGE plpgsql;
+

--- a/orafce.control
+++ b/orafce.control
@@ -1,5 +1,5 @@
 # orafce extension
 comment = 'Functions and operators that emulate a subset of functions and packages from the Oracle RDBMS'
-default_version = '3.16'
+default_version = '3.17'
 module_pathname = '$libdir/orafce'
 relocatable = false

--- a/sql/regexp_func.sql
+++ b/sql/regexp_func.sql
@@ -247,3 +247,51 @@ SELECT oracle.REGEXP_REPLACE ('A PostgreSQL function', 'a|e|i|o|u', 'X', 1, -1, 
 -- ORACLE> SELECT REGEXP_REPLACE ('A PostgreSQL function', 'a|e|i|o|u', 'X', 1, 1, 'g') FROM DUAL; -> ORA-01760
 SELECT oracle.REGEXP_REPLACE ('A PostgreSQL function', 'a|e|i|o|u', 'X', 1, 1, 'g');
 
+--
+-- Test NULL input in the regexp_* functions that must returned NULL except for the modifier
+-- or regexp flag. There is an exception with regexp_replace(), if the pattern is null (second
+-- parameter) the original string is returned. We don't test functions witht the STRICT attribute
+--
+SELECT oracle.REGEXP_LIKE(NULL, '\d+', 'i');
+SELECT oracle.REGEXP_LIKE('1234', NULL, 'i');
+SELECT oracle.REGEXP_LIKE('1234', '\d+', NULL);
+SELECT oracle.REGEXP_LIKE('1234', '\d+', '');
+SELECT oracle.REGEXP_COUNT('1234', '\d', NULL) ;
+SELECT oracle.REGEXP_COUNT('1234', '\d', 1, NULL) ;
+SELECT oracle.REGEXP_COUNT('1234', '\d', 1, '') ;
+SELECT oracle.REGEXP_COUNT('1234', '\d', NULL, NULL) ;
+SELECT oracle.REGEXP_COUNT(NULL, '4', 1, 'i');
+SELECT oracle.REGEXP_INSTR('1234', '4', NULL);
+SELECT oracle.REGEXP_INSTR('1234', '4', 1, NULL);
+SELECT oracle.REGEXP_INSTR('1234', '4', 1, 1, NULL);
+SELECT oracle.REGEXP_INSTR('1234', '4', 1, 1, 1, NULL);
+SELECT oracle.REGEXP_INSTR('1234', '4', 1, 1, 0, NULL);
+SELECT oracle.REGEXP_INSTR('1234', '4', 1, 1, 0, 'i', NULL);
+SELECT oracle.REGEXP_INSTR('1234', '4', 1, 1, 0, '', NULL);
+SELECT oracle.REGEXP_INSTR(NULL, '4', 1, 1, 0, 'i', 2);
+SELECT oracle.REGEXP_INSTR(NULL, '4', 1, 1, 0, 'i', 2);
+SELECT oracle.REGEXP_SUBSTR('1234', '1(.*)', null);
+SELECT oracle.REGEXP_SUBSTR('1234', '234', 1, null);
+SELECT oracle.REGEXP_SUBSTR('1234', '234', 1, 1, null);
+SELECT oracle.REGEXP_SUBSTR('1234', '234', 1, 1, '');
+SELECT oracle.REGEXP_SUBSTR('1234', '234', 1, 1, 'i', null);
+-- test for capture group
+SELECT oracle.REGEXP_SUBSTR('1234', '2(3)(4)', 1, 1, 'i', 1);
+SELECT oracle.REGEXP_SUBSTR('1234', '2(3)(4)', 1, 1, 'i', 2);
+SELECT oracle.REGEXP_SUBSTR('1234', '2(3)(4)', 1, 1, 'i', 0);
+-- Special case for second parameter in REGEXP_REPLACE, when null returns the original value.
+SELECT oracle.REGEXP_REPLACE(null, '\d', 'a');
+SELECT oracle.REGEXP_REPLACE('1234', null, 'a');
+SELECT oracle.REGEXP_REPLACE('1234', null, null);
+SELECT oracle.REGEXP_REPLACE('1234', '\d', null);
+SELECT oracle.REGEXP_REPLACE('1234', '\d', 'a', null);
+SELECT oracle.REGEXP_REPLACE('1234', null, 'a', 2);
+SELECT oracle.REGEXP_REPLACE('1234', null, 'a', null);
+SELECT oracle.REGEXP_REPLACE('1234', null, 'a', 1);
+SELECT oracle.REGEXP_REPLACE('1234', null, 'a', 1, null);
+SELECT oracle.REGEXP_REPLACE('1234', '\d', 'a', 1, null);
+SELECT oracle.REGEXP_REPLACE('1234', '\d', 'a', 1, null);
+SELECT oracle.REGEXP_REPLACE('1234', '\d', 'a', 1, null);
+SELECT oracle.REGEXP_REPLACE('1234', '\d', 'a', 1, 1, null);
+SELECT oracle.REGEXP_REPLACE('1234', '\d', 'a', 1, NULL, 'i');
+SELECT oracle.REGEXP_REPLACE('1234', null, 'a', 1, 1, 'i');


### PR DESCRIPTION
null input.

Actually all NULL inputs in the regexp_* functions must returned NULL
except for the modifier regexp flag. There is an exception with function
regexp_replace(), if the pattern is null (second parameter) the original
string is returned provided that there is no other null parameter except
for the modifier.

The patch fix also function oracle.regexp_substr() that was failing to
return the right capture group when asked.