### PR TITLE
Catch dbms_random.string() output variation on Windows

### DIFF
--- a/expected/dbms_random_2.out
+++ b/expected/dbms_random_2.out
@@ -1,0 +1,91 @@
+-- Tests for package DBMS_RANDOM
+SELECT dbms_random.initialize(8);
+ initialize 
+------------
+ 
+(1 row)
+
+SELECT dbms_random.normal()::numeric(10, 8);
+   normal    
+-------------
+ -2.88076095
+(1 row)
+
+SELECT dbms_random.normal()::numeric(10, 8);
+   normal   
+------------
+ 1.07890275
+(1 row)
+
+SELECT dbms_random.seed(8);
+ seed 
+------
+ 
+(1 row)
+
+SELECT dbms_random.random();
+ random 
+--------
+ -32638
+(1 row)
+
+SELECT dbms_random.seed('test');
+ seed 
+------
+ 
+(1 row)
+
+SELECT dbms_random.string('U',5);
+ string 
+--------
+ XXEJF
+(1 row)
+
+SELECT dbms_random.string('P',2);
+ string 
+--------
+ fo
+(1 row)
+
+SELECT dbms_random.string('x',4);
+ string 
+--------
+ V3W9
+(1 row)
+
+SELECT dbms_random.string('a',2);
+ string 
+--------
+ GC
+(1 row)
+
+SELECT dbms_random.string('l',3);
+ string 
+--------
+ pbr
+(1 row)
+
+SELECT dbms_random.seed(5);
+ seed 
+------
+ 
+(1 row)
+
+SELECT dbms_random.value()::numeric(10, 8);
+   value    
+------------
+ 0.00164795
+(1 row)
+
+SELECT dbms_random.value(10,15)::numeric(10, 8);
+    value    
+-------------
+ 14.37820435
+(1 row)
+
+SELECT dbms_random.terminate();
+ terminate 
+-----------
+ 
+(1 row)
+


### PR DESCRIPTION
Hi

On Windows architectures, the dbms_random.string() output is
different. Allow regression tests to pass by adding an alternate _2.out
file.

I did not investigate if it would be possible to tweak the code such that the output is the same on all architectures. That might be the better fix; my variant was the easier one.