### PR TITLE
Change behaior of the least() and greates() functions to reflect the same behavior as Oracle

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ OBJS= parse_keyword.o convert.o file.o datefce.o magic.o others.o plvstr.o plvda
 
 EXTENSION = orafce
 
-DATA = orafce--3.17.sql orafce--3.2--3.3.sql orafce--3.3--3.4.sql orafce--3.4--3.5.sql orafce--3.5--3.6.sql orafce--3.6--3.7.sql orafce--3.7--3.8.sql orafce--3.8--3.9.sql orafce--3.9--3.10.sql orafce--3.10--3.11.sql orafce--3.11--3.12.sql orafce--3.12--3.13.sql orafce--3.13--3.14.sql orafce--3.14--3.15.sql orafce--3.15--3.16.sql orafce--3.16--3.17.sql
+DATA = orafce--3.18.sql orafce--3.2--3.3.sql orafce--3.3--3.4.sql orafce--3.4--3.5.sql orafce--3.5--3.6.sql orafce--3.6--3.7.sql orafce--3.7--3.8.sql orafce--3.8--3.9.sql orafce--3.9--3.10.sql orafce--3.10--3.11.sql orafce--3.11--3.12.sql orafce--3.12--3.13.sql orafce--3.13--3.14.sql orafce--3.14--3.15.sql orafce--3.15--3.16.sql orafce--3.16--3.17.sql orafce--3.17--3.18.sql
 DOCS = README.asciidoc COPYRIGHT.orafce INSTALL.orafce
 
 PG_CONFIG ?= pg_config

--- a/expected/orafce.out
+++ b/expected/orafce.out
@@ -4400,3 +4400,230 @@ SELECT oracle.unistr('wrong: \U0000db99\U00000061');
 ERROR:  invalid Unicode surrogate pair
 SELECT oracle.unistr('wrong: \U002FFFFF');
 ERROR:  invalid Unicode escape value
+----
+-- Tests for the greatest/least scalar function
+----
+-- The PostgreSQL native function returns NULL only if all parameters are nulls
+SELECT greatest(2, 6, 8);
+ greatest 
+----------
+        8
+(1 row)
+
+SELECT greatest(2, NULL, 8);
+ greatest 
+----------
+        8
+(1 row)
+
+SELECT least(2, 6, 8);
+ least 
+-------
+     2
+(1 row)
+
+SELECT least(2, NULL, 8);
+ least 
+-------
+     2
+(1 row)
+
+-- The Oracle function returns NULL on NULL input, even a single parameter
+SELECT oracle.greatest(2, 6, 8);
+ greatest 
+----------
+        8
+(1 row)
+
+SELECT oracle.greatest(2, NULL, 8);
+ greatest 
+----------
+      ***
+(1 row)
+
+SELECT oracle.least(2, 6, 8);
+ least 
+-------
+     2
+(1 row)
+
+SELECT oracle.least(2, NULL, 8);
+ least 
+-------
+   ***
+(1 row)
+
+SELECT oracle.greatest('A', 'B', 'C');
+ greatest 
+----------
+ C
+(1 row)
+
+SELECT oracle.greatest('A', NULL, 'C');
+ greatest 
+----------
+ ***
+(1 row)
+
+SELECT oracle.least('A', 'B', 'C');
+ least 
+-------
+ A
+(1 row)
+
+SELECT oracle.least('A', NULL, 'C');
+ least 
+-------
+ ***
+(1 row)
+
+SELECT oracle.greatest(2.4, 2.5, 2.7);
+ greatest 
+----------
+      2.7
+(1 row)
+
+SELECT oracle.greatest(2.4, NULL, 2.7);
+ greatest 
+----------
+      ***
+(1 row)
+
+SELECT oracle.least(2.4, 2.5, 2.7);
+ least 
+-------
+   2.4
+(1 row)
+
+SELECT oracle.least(2.4, NULL, 2.7);
+ least 
+-------
+   ***
+(1 row)
+
+-- Both don't like data type mix
+SELECT greatest(2, 'A', 'B');
+ERROR:  invalid input syntax for type integer: "A"
+LINE 1: SELECT greatest(2, 'A', 'B');
+                           ^
+SELECT oracle.greatest(2, 'A', 'B');
+ERROR:  invalid input syntax for type integer: "A"
+LINE 1: SELECT oracle.greatest(2, 'A', 'B');
+                                  ^
+SELECT greatest('A', 'B', '1');
+ greatest 
+----------
+ B
+(1 row)
+
+SELECT oracle.greatest('A', 'B', '1');
+ greatest 
+----------
+ B
+(1 row)
+
+SELECT greatest('A', 'B', 1);
+ERROR:  invalid input syntax for type integer: "A"
+LINE 1: SELECT greatest('A', 'B', 1);
+                        ^
+SELECT oracle.greatest('A', 'B', 1);
+ERROR:  invalid input syntax for type integer: "A"
+LINE 1: SELECT oracle.greatest('A', 'B', 1);
+                               ^
+-- Test different data type
+SELECT oracle.greatest('A'::text, 'B'::text);
+ greatest 
+----------
+ B
+(1 row)
+
+SELECT oracle.greatest('A'::bpchar, 'B'::bpchar);
+ greatest 
+----------
+ B
+(1 row)
+
+SELECT oracle.greatest(1::bigint,2::bigint);
+ greatest 
+----------
+        2
+(1 row)
+
+SELECT oracle.greatest(1::integer,2::integer);
+ greatest 
+----------
+        2
+(1 row)
+
+SELECT oracle.greatest(1::smallint,2::smallint);
+ greatest 
+----------
+        2
+(1 row)
+
+SELECT oracle.greatest(1.2::numeric,2.4::numeric);
+ greatest 
+----------
+      2.4
+(1 row)
+
+SELECT oracle.greatest(1.2::double precision,2.4::double precision);
+ greatest 
+----------
+      2.4
+(1 row)
+
+SELECT oracle.greatest(1.2::real,2.4::real);
+      greatest      
+--------------------
+ 2.4000000953674316
+(1 row)
+
+SELECT oracle.least('A'::text, 'B'::text);
+ least 
+-------
+ A
+(1 row)
+
+SELECT oracle.least('A'::bpchar, 'B'::bpchar);
+ least 
+-------
+ A
+(1 row)
+
+SELECT oracle.least(1::bigint,2::bigint);
+ least 
+-------
+     1
+(1 row)
+
+SELECT oracle.least(1::integer,2::integer);
+ least 
+-------
+     1
+(1 row)
+
+SELECT oracle.least(1::smallint,2::smallint);
+ least 
+-------
+     1
+(1 row)
+
+SELECT oracle.least(1.2::numeric,2.4::numeric);
+ least 
+-------
+   1.2
+(1 row)
+
+SELECT oracle.least(1.2::double precision,2.4::double precision);
+ least 
+-------
+   1.2
+(1 row)
+
+SELECT oracle.least(1.2::real,2.4::real);
+       least        
+--------------------
+ 1.2000000476837158
+(1 row)
+

--- a/orafce--3.17--3.18.sql
+++ b/orafce--3.17--3.18.sql
@@ -1,0 +1,204 @@
+----
+-- Add LEAST/GREATEST declaration to return NULL on NULL input.
+-- PostgreSQL only returns NULL when all the parameters are NULL.
+----
+
+-- GREATEST
+CREATE FUNCTION oracle.greatest(VARIADIC text[]) RETURNS text AS $$
+BEGIN
+   IF array_position($1, NULL) IS NOT NULL THEN
+       RETURN NULL;
+   END IF;
+   RETURN max(x) FROM unnest($1) x;
+END
+$$ LANGUAGE PLPGSQL;
+
+CREATE FUNCTION oracle.greatest(VARIADIC bpchar[]) RETURNS bpchar AS $$
+BEGIN
+   IF array_position($1, NULL) IS NOT NULL THEN
+       RETURN NULL;
+   END IF;
+   RETURN max(x) FROM unnest($1) x;
+END
+$$ LANGUAGE PLPGSQL;
+
+CREATE FUNCTION oracle.greatest(VARIADIC bigint[]) RETURNS bigint AS $$
+BEGIN
+   IF array_position($1, NULL) IS NOT NULL THEN
+       RETURN NULL;
+   END IF;
+   RETURN max(x) FROM unnest($1) x;
+END
+$$ LANGUAGE PLPGSQL;
+
+CREATE FUNCTION oracle.greatest(VARIADIC integer[]) RETURNS integer AS $$
+BEGIN
+   IF array_position($1, NULL) IS NOT NULL THEN
+       RETURN NULL;
+   END IF;
+   RETURN max(x) FROM unnest($1) x;
+END
+$$ LANGUAGE PLPGSQL;
+
+CREATE FUNCTION oracle.greatest(VARIADIC smallint[]) RETURNS smallint AS $$
+BEGIN
+   IF array_position($1, NULL) IS NOT NULL THEN
+       RETURN NULL;
+   END IF;
+   RETURN max(x) FROM unnest($1) x;
+END
+$$ LANGUAGE PLPGSQL;
+
+CREATE FUNCTION oracle.greatest(VARIADIC numeric[]) RETURNS numeric AS $$
+BEGIN
+   IF array_position($1, NULL) IS NOT NULL THEN
+       RETURN NULL;
+   END IF;
+   RETURN max(x) FROM unnest($1) x;
+END
+$$ LANGUAGE PLPGSQL;
+
+CREATE FUNCTION oracle.greatest(VARIADIC double precision[]) RETURNS double precision AS $$
+BEGIN
+   IF array_position($1, NULL) IS NOT NULL THEN
+       RETURN NULL;
+   END IF;
+   RETURN max(x) FROM unnest($1) x;
+END
+$$ LANGUAGE PLPGSQL;
+
+CREATE FUNCTION oracle.greatest(VARIADIC timestamp[]) RETURNS timestamp AS $$
+BEGIN
+   IF array_position($1, NULL) IS NOT NULL THEN
+       RETURN NULL;
+   END IF;
+   RETURN max(x) FROM unnest($1) x;
+END
+$$ LANGUAGE PLPGSQL;
+
+CREATE FUNCTION oracle.greatest(VARIADIC timestamptz[]) RETURNS timestamptz AS $$
+BEGIN
+   IF array_position($1, NULL) IS NOT NULL THEN
+       RETURN NULL;
+   END IF;
+   RETURN max(x) FROM unnest($1) x;
+END
+$$ LANGUAGE PLPGSQL;
+
+CREATE FUNCTION oracle.greatest(VARIADIC date[]) RETURNS date AS $$
+BEGIN
+   IF array_position($1, NULL) IS NOT NULL THEN
+       RETURN NULL;
+   END IF;
+   RETURN max(x) FROM unnest($1) x;
+END
+$$ LANGUAGE PLPGSQL;
+
+CREATE FUNCTION oracle.greatest(VARIADIC time[]) RETURNS time AS $$
+BEGIN
+   IF array_position($1, NULL) IS NOT NULL THEN
+       RETURN NULL;
+   END IF;
+   RETURN max(x) FROM unnest($1) x;
+END
+$$ LANGUAGE PLPGSQL;
+
+-- LEAST
+CREATE FUNCTION oracle.least(VARIADIC text[]) RETURNS text AS $$
+BEGIN
+   IF array_position($1, NULL) IS NOT NULL THEN
+       RETURN NULL;
+   END IF;
+   RETURN min(x) FROM unnest($1) x;
+END
+$$ LANGUAGE PLPGSQL;
+
+CREATE FUNCTION oracle.least(VARIADIC bpchar[]) RETURNS bpchar AS $$
+BEGIN
+   IF array_position($1, NULL) IS NOT NULL THEN
+       RETURN NULL;
+   END IF;
+   RETURN min(x) FROM unnest($1) x;
+END
+$$ LANGUAGE PLPGSQL;
+
+CREATE FUNCTION oracle.least(VARIADIC bigint[]) RETURNS bigint AS $$
+BEGIN
+   IF array_position($1, NULL) IS NOT NULL THEN
+       RETURN NULL;
+   END IF;
+   RETURN min(x) FROM unnest($1) x;
+END
+$$ LANGUAGE PLPGSQL;
+
+CREATE FUNCTION oracle.least(VARIADIC integer[]) RETURNS integer AS $$
+BEGIN
+   IF array_position($1, NULL) IS NOT NULL THEN
+       RETURN NULL;
+   END IF;
+   RETURN min(x) FROM unnest($1) x;
+END
+$$ LANGUAGE PLPGSQL;
+
+CREATE FUNCTION oracle.least(VARIADIC smallint[]) RETURNS smallint AS $$
+BEGIN
+   IF array_position($1, NULL) IS NOT NULL THEN
+       RETURN NULL;
+   END IF;
+   RETURN min(x) FROM unnest($1) x;
+END
+$$ LANGUAGE PLPGSQL;
+
+CREATE FUNCTION oracle.least(VARIADIC numeric[]) RETURNS numeric AS $$
+BEGIN
+   IF array_position($1, NULL) IS NOT NULL THEN
+       RETURN NULL;
+   END IF;
+   RETURN min(x) FROM unnest($1) x;
+END
+$$ LANGUAGE PLPGSQL;
+
+CREATE FUNCTION oracle.least(VARIADIC double precision[]) RETURNS double precision AS $$
+BEGIN
+   IF array_position($1, NULL) IS NOT NULL THEN
+       RETURN NULL;
+   END IF;
+   RETURN min(x) FROM unnest($1) x;
+END
+$$ LANGUAGE PLPGSQL;
+
+CREATE FUNCTION oracle.least(VARIADIC timestamp[]) RETURNS timestamp AS $$
+BEGIN
+   IF array_position($1, NULL) IS NOT NULL THEN
+       RETURN NULL;
+   END IF;
+   RETURN min(x) FROM unnest($1) x;
+END
+$$ LANGUAGE PLPGSQL;
+
+CREATE FUNCTION oracle.least(VARIADIC timestamptz[]) RETURNS timestamptz AS $$
+BEGIN
+   IF array_position($1, NULL) IS NOT NULL THEN
+       RETURN NULL;
+   END IF;
+   RETURN min(x) FROM unnest($1) x;
+END
+$$ LANGUAGE PLPGSQL;
+
+CREATE FUNCTION oracle.least(VARIADIC date[]) RETURNS date AS $$
+BEGIN
+   IF array_position($1, NULL) IS NOT NULL THEN
+       RETURN NULL;
+   END IF;
+   RETURN min(x) FROM unnest($1) x;
+END
+$$ LANGUAGE PLPGSQL;
+
+CREATE FUNCTION oracle.least(VARIADIC time[]) RETURNS time AS $$
+BEGIN
+   IF array_position($1, NULL) IS NOT NULL THEN
+       RETURN NULL;
+   END IF;
+   RETURN min(x) FROM unnest($1) x;
+END
+$$ LANGUAGE PLPGSQL;

--- a/orafce--3.18.sql
+++ b/orafce--3.18.sql
@@ -1,4 +1,4 @@
-/* orafce--3.17.sql */
+/* orafce--3.18.sql */
 
 -- complain if script is sourced in psql, rather than via CREATE EXTENSION
 \echo Use "CREATE EXTENSION orafce" to load this file. \quit
@@ -4242,3 +4242,208 @@ BEGIN
 END;
 $$
 LANGUAGE plpgsql;
+
+----
+-- Add LEAST/GREATEST declaration to return NULL on NULL input.
+-- PostgreSQL only returns NULL when all the parameters are NULL.
+----
+
+-- GREATEST
+CREATE FUNCTION oracle.greatest(VARIADIC text[]) RETURNS text AS $$
+BEGIN
+   IF array_position($1, NULL) IS NOT NULL THEN
+       RETURN NULL;
+   END IF;
+   RETURN max(x) FROM unnest($1) x;
+END
+$$ LANGUAGE PLPGSQL;
+
+CREATE FUNCTION oracle.greatest(VARIADIC bpchar[]) RETURNS bpchar AS $$
+BEGIN
+   IF array_position($1, NULL) IS NOT NULL THEN
+       RETURN NULL;
+   END IF;
+   RETURN max(x) FROM unnest($1) x;
+END
+$$ LANGUAGE PLPGSQL;
+
+CREATE FUNCTION oracle.greatest(VARIADIC bigint[]) RETURNS bigint AS $$
+BEGIN
+   IF array_position($1, NULL) IS NOT NULL THEN
+       RETURN NULL;
+   END IF;
+   RETURN max(x) FROM unnest($1) x;
+END
+$$ LANGUAGE PLPGSQL;
+
+CREATE FUNCTION oracle.greatest(VARIADIC integer[]) RETURNS integer AS $$
+BEGIN
+   IF array_position($1, NULL) IS NOT NULL THEN
+       RETURN NULL;
+   END IF;
+   RETURN max(x) FROM unnest($1) x;
+END
+$$ LANGUAGE PLPGSQL;
+
+CREATE FUNCTION oracle.greatest(VARIADIC smallint[]) RETURNS smallint AS $$
+BEGIN
+   IF array_position($1, NULL) IS NOT NULL THEN
+       RETURN NULL;
+   END IF;
+   RETURN max(x) FROM unnest($1) x;
+END
+$$ LANGUAGE PLPGSQL;
+
+CREATE FUNCTION oracle.greatest(VARIADIC numeric[]) RETURNS numeric AS $$
+BEGIN
+   IF array_position($1, NULL) IS NOT NULL THEN
+       RETURN NULL;
+   END IF;
+   RETURN max(x) FROM unnest($1) x;
+END
+$$ LANGUAGE PLPGSQL;
+
+CREATE FUNCTION oracle.greatest(VARIADIC double precision[]) RETURNS double precision AS $$
+BEGIN
+   IF array_position($1, NULL) IS NOT NULL THEN
+       RETURN NULL;
+   END IF;
+   RETURN max(x) FROM unnest($1) x;
+END
+$$ LANGUAGE PLPGSQL;
+
+CREATE FUNCTION oracle.greatest(VARIADIC timestamp[]) RETURNS timestamp AS $$
+BEGIN
+   IF array_position($1, NULL) IS NOT NULL THEN
+       RETURN NULL;
+   END IF;
+   RETURN max(x) FROM unnest($1) x;
+END
+$$ LANGUAGE PLPGSQL;
+
+CREATE FUNCTION oracle.greatest(VARIADIC timestamptz[]) RETURNS timestamptz AS $$
+BEGIN
+   IF array_position($1, NULL) IS NOT NULL THEN
+       RETURN NULL;
+   END IF;
+   RETURN max(x) FROM unnest($1) x;
+END
+$$ LANGUAGE PLPGSQL;
+
+CREATE FUNCTION oracle.greatest(VARIADIC date[]) RETURNS date AS $$
+BEGIN
+   IF array_position($1, NULL) IS NOT NULL THEN
+       RETURN NULL;
+   END IF;
+   RETURN max(x) FROM unnest($1) x;
+END
+$$ LANGUAGE PLPGSQL;
+
+CREATE FUNCTION oracle.greatest(VARIADIC time[]) RETURNS time AS $$
+BEGIN
+   IF array_position($1, NULL) IS NOT NULL THEN
+       RETURN NULL;
+   END IF;
+   RETURN max(x) FROM unnest($1) x;
+END
+$$ LANGUAGE PLPGSQL;
+
+-- LEAST
+CREATE FUNCTION oracle.least(VARIADIC text[]) RETURNS text AS $$
+BEGIN
+   IF array_position($1, NULL) IS NOT NULL THEN
+       RETURN NULL;
+   END IF;
+   RETURN min(x) FROM unnest($1) x;
+END
+$$ LANGUAGE PLPGSQL;
+
+CREATE FUNCTION oracle.least(VARIADIC bpchar[]) RETURNS bpchar AS $$
+BEGIN
+   IF array_position($1, NULL) IS NOT NULL THEN
+       RETURN NULL;
+   END IF;
+   RETURN min(x) FROM unnest($1) x;
+END
+$$ LANGUAGE PLPGSQL;
+
+CREATE FUNCTION oracle.least(VARIADIC bigint[]) RETURNS bigint AS $$
+BEGIN
+   IF array_position($1, NULL) IS NOT NULL THEN
+       RETURN NULL;
+   END IF;
+   RETURN min(x) FROM unnest($1) x;
+END
+$$ LANGUAGE PLPGSQL;
+
+CREATE FUNCTION oracle.least(VARIADIC integer[]) RETURNS integer AS $$
+BEGIN
+   IF array_position($1, NULL) IS NOT NULL THEN
+       RETURN NULL;
+   END IF;
+   RETURN min(x) FROM unnest($1) x;
+END
+$$ LANGUAGE PLPGSQL;
+
+CREATE FUNCTION oracle.least(VARIADIC smallint[]) RETURNS smallint AS $$
+BEGIN
+   IF array_position($1, NULL) IS NOT NULL THEN
+       RETURN NULL;
+   END IF;
+   RETURN min(x) FROM unnest($1) x;
+END
+$$ LANGUAGE PLPGSQL;
+
+CREATE FUNCTION oracle.least(VARIADIC numeric[]) RETURNS numeric AS $$
+BEGIN
+   IF array_position($1, NULL) IS NOT NULL THEN
+       RETURN NULL;
+   END IF;
+   RETURN min(x) FROM unnest($1) x;
+END
+$$ LANGUAGE PLPGSQL;
+
+CREATE FUNCTION oracle.least(VARIADIC double precision[]) RETURNS double precision AS $$
+BEGIN
+   IF array_position($1, NULL) IS NOT NULL THEN
+       RETURN NULL;
+   END IF;
+   RETURN min(x) FROM unnest($1) x;
+END
+$$ LANGUAGE PLPGSQL;
+
+CREATE FUNCTION oracle.least(VARIADIC timestamp[]) RETURNS timestamp AS $$
+BEGIN
+   IF array_position($1, NULL) IS NOT NULL THEN
+       RETURN NULL;
+   END IF;
+   RETURN min(x) FROM unnest($1) x;
+END
+$$ LANGUAGE PLPGSQL;
+
+CREATE FUNCTION oracle.least(VARIADIC timestamptz[]) RETURNS timestamptz AS $$
+BEGIN
+   IF array_position($1, NULL) IS NOT NULL THEN
+       RETURN NULL;
+   END IF;
+   RETURN min(x) FROM unnest($1) x;
+END
+$$ LANGUAGE PLPGSQL;
+
+CREATE FUNCTION oracle.least(VARIADIC date[]) RETURNS date AS $$
+BEGIN
+   IF array_position($1, NULL) IS NOT NULL THEN
+       RETURN NULL;
+   END IF;
+   RETURN min(x) FROM unnest($1) x;
+END
+$$ LANGUAGE PLPGSQL;
+
+CREATE FUNCTION oracle.least(VARIADIC time[]) RETURNS time AS $$
+BEGIN
+   IF array_position($1, NULL) IS NOT NULL THEN
+       RETURN NULL;
+   END IF;
+   RETURN min(x) FROM unnest($1) x;
+END
+$$ LANGUAGE PLPGSQL;

--- a/orafce.control
+++ b/orafce.control
@@ -1,5 +1,5 @@
 # orafce extension
 comment = 'Functions and operators that emulate a subset of functions and packages from the Oracle RDBMS'
-default_version = '3.17'
+default_version = '3.18'
 module_pathname = '$libdir/orafce'
 relocatable = false

--- a/sql/orafce.sql
+++ b/sql/orafce.sql
@@ -1031,3 +1031,53 @@ SELECT oracle.unistr('wrong: \+2FFFFF');
 SELECT oracle.unistr('wrong: \udb99\u0061');
 SELECT oracle.unistr('wrong: \U0000db99\U00000061');
 SELECT oracle.unistr('wrong: \U002FFFFF');
+
+
+----
+-- Tests for the greatest/least scalar function
+----
+-- The PostgreSQL native function returns NULL only if all parameters are nulls
+SELECT greatest(2, 6, 8);
+SELECT greatest(2, NULL, 8);
+SELECT least(2, 6, 8);
+SELECT least(2, NULL, 8);
+
+-- The Oracle function returns NULL on NULL input, even a single parameter
+SELECT oracle.greatest(2, 6, 8);
+SELECT oracle.greatest(2, NULL, 8);
+SELECT oracle.least(2, 6, 8);
+SELECT oracle.least(2, NULL, 8);
+SELECT oracle.greatest('A', 'B', 'C');
+SELECT oracle.greatest('A', NULL, 'C');
+SELECT oracle.least('A', 'B', 'C');
+SELECT oracle.least('A', NULL, 'C');
+SELECT oracle.greatest(2.4, 2.5, 2.7);
+SELECT oracle.greatest(2.4, NULL, 2.7);
+SELECT oracle.least(2.4, 2.5, 2.7);
+SELECT oracle.least(2.4, NULL, 2.7);
+
+-- Both don't like data type mix
+SELECT greatest(2, 'A', 'B');
+SELECT oracle.greatest(2, 'A', 'B');
+SELECT greatest('A', 'B', '1');
+SELECT oracle.greatest('A', 'B', '1');
+SELECT greatest('A', 'B', 1);
+SELECT oracle.greatest('A', 'B', 1);
+
+-- Test different data type
+SELECT oracle.greatest('A'::text, 'B'::text);
+SELECT oracle.greatest('A'::bpchar, 'B'::bpchar);
+SELECT oracle.greatest(1::bigint,2::bigint);
+SELECT oracle.greatest(1::integer,2::integer);
+SELECT oracle.greatest(1::smallint,2::smallint);
+SELECT oracle.greatest(1.2::numeric,2.4::numeric);
+SELECT oracle.greatest(1.2::double precision,2.4::double precision);
+SELECT oracle.greatest(1.2::real,2.4::real);
+SELECT oracle.least('A'::text, 'B'::text);
+SELECT oracle.least('A'::bpchar, 'B'::bpchar);
+SELECT oracle.least(1::bigint,2::bigint);
+SELECT oracle.least(1::integer,2::integer);
+SELECT oracle.least(1::smallint,2::smallint);
+SELECT oracle.least(1.2::numeric,2.4::numeric);
+SELECT oracle.least(1.2::double precision,2.4::double precision);
+SELECT oracle.least(1.2::real,2.4::real);


### PR DESCRIPTION
Oracle functions LEAST and GREATEST return NULL if at least one of the
parameters is NULL. This is not the case for the PostgreSQL equivalent
functions which only return NULL when all the parameters are NULL. This
patch creates the two function in the oracle schema to have the same
behavior than in Oracle.