### PR TITLE
Change behavior of the least() and greates() functions to return null on null input

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ OBJS= parse_keyword.o convert.o file.o datefce.o magic.o others.o plvstr.o plvda
 
 EXTENSION = orafce
 
-DATA = orafce--3.17.sql orafce--3.2--3.3.sql orafce--3.3--3.4.sql orafce--3.4--3.5.sql orafce--3.5--3.6.sql orafce--3.6--3.7.sql orafce--3.7--3.8.sql orafce--3.8--3.9.sql orafce--3.9--3.10.sql orafce--3.10--3.11.sql orafce--3.11--3.12.sql orafce--3.12--3.13.sql orafce--3.13--3.14.sql orafce--3.14--3.15.sql orafce--3.15--3.16.sql orafce--3.16--3.17.sql
+DATA = orafce--3.18.sql orafce--3.2--3.3.sql orafce--3.3--3.4.sql orafce--3.4--3.5.sql orafce--3.5--3.6.sql orafce--3.6--3.7.sql orafce--3.7--3.8.sql orafce--3.8--3.9.sql orafce--3.9--3.10.sql orafce--3.10--3.11.sql orafce--3.11--3.12.sql orafce--3.12--3.13.sql orafce--3.13--3.14.sql orafce--3.14--3.15.sql orafce--3.15--3.16.sql orafce--3.16--3.17.sql orafce--3.17--3.18.sql
 DOCS = README.asciidoc COPYRIGHT.orafce INSTALL.orafce
 
 PG_CONFIG ?= pg_config

--- a/README.asciidoc
+++ b/README.asciidoc
@@ -653,7 +653,7 @@ This unit contains some assert functions.
 
 == Others functions
 
-This module contains implementation of functions: concat, nvl, nvl2, lnnvl, decode,
+This module contains implementation of functions: concat, nvl, nvl2, lnnvl, decode, greatest, least,
 bitand, nanvl, sinh, cosh, tanh and oracle.substr.
 
 * oracle.substr(str text, start int, len int) - Oracle compatible substring
@@ -677,9 +677,13 @@ bitand, nanvl, sinh, cosh, tanh and oracle.substr.
 * pg_catalog.to_number(numeric,numeric) -  converts a string to a number
 * public.to_multi_byte(text) - Convert all single-byte characters to their corresponding multibyte characters
 * public.to_single_byte(text) - Convert all multi-byte characters to their corresponding single-byte characters
+* oracle.greatest(anyelement, anyelement[]) - Oracle compatibility greatest, return NULL on NULL input
+* oracle.least(anyelement, anyelement[]) - Oracle compatibility least, return NULL on NULL input
 
 You might need to set search_path to 'oracle, pg_catalog, "$user", public'
 because oracle.substr, oracle.lpad, oracle.rpad, oracle.ltrim, oracle.rtrim, oracle.btrim, oracle.length are installed side-by-side with pg_catalog.substr, pg_catalog.lpad, pg_catalog.rpad, pg_catalog.ltrim, pg_catalog.rtrim, pg_catalog.btrim, pg_catalog.length respectively.
+
+Functions oracle.decode, oracle.greatest and oracle.least must always be prefixed by the schema name even if the oracle is before pg_catalog in the search_path because these functions are implemented inside PostgreSQL parser and analyzer. Without the schema name the internal functions will always be used.
 
 Note that in case of lpad and rpad, parameters string and fill can be of types CHAR, VARCHAR, TEXT, VARCHAR2 or NVARCHAR2 (note that the last two are orafce-provided types). The default fill character is a half-width space. Similarly for ltrim, rtrim and btrim.
 

--- a/doc/orafce_documentation/Orafce_Documentation_01.md
+++ b/doc/orafce_documentation/Orafce_Documentation_01.md
@@ -98,6 +98,8 @@ The table below lists features compatible with Oracle databases.
 |Item|Overview|
 |:---|:---|
 |DECODE|Compares values, and if they match, returns a corresponding value|
+|GREATEST|Returns the greatest of the list of one or more expressions|
+|LEAST|Returns the least of the list of one or more expressions|
 |LNNVL|Evaluates if a value is false or unknown|
 |NANVL|Returns a substitute value when a value is not a number (NaN)|
 |NVL|Returns a substitute value when a value is NULL|

--- a/doc/orafce_documentation/Orafce_Documentation_05.md
+++ b/doc/orafce_documentation/Orafce_Documentation_05.md
@@ -1794,6 +1794,8 @@ SELECT TO_SINGLE_BYTE('******') FROM DUAL;
 The following functions for making comparisons are supported:
 
  - DECODE
+ - GREATEST
+ - LEAST
  - LNNVL
  - NANVL
  - NVL
@@ -1957,7 +1959,51 @@ col1  | num-word
 
 ----
 
-#### 5.5.2 LNNVL
+#### 5.5.2 GREATEST and LEAST
+
+**Description**
+
+The GREATEST and LEAST functions select the largest or smallest value from a list of any number of expressions. The expressions must all be convertible to a common data type, which will be the type of the result
+
+**Syntax**
+
+```
+GREATEST(value [, ...])
+
+LEAST(value [, ...])
+```
+
+**General rules**
+
+ - These two function are the same behavior than the POstgreSQL one except that instead of retunring NULL only when all parameters are NULL ,they return NULL when one of the parameters is NULL like in Oracle.
+
+**Example**
+
+----
+
+In the following example, col1 and col3 of table t1 are returned when col3 has a value of 2000 or less, or null values.
+
+~~~
+SELECT GREATEST ('C', 'F', 'E')
+ greatest
+----------
+ F 
+(1 row)
+~~~
+
+~~~
+\pset null ###
+SELECT LEAST ('C', NULL, 'E')
+ greatest
+----------
+ ###
+(1 row)
+~~~
+
+----
+
+
+#### 5.5.3 LNNVL
 
 **Description**
 
@@ -1991,7 +2037,7 @@ SELECT col1,col3 FROM t1 WHERE LNNVL( col3 > 2000 );
 
 ----
 
-#### 5.5.3 NANVL
+#### 5.5.4 NANVL
 
 **Description**
 
@@ -2024,7 +2070,7 @@ SELECT col1, NANVL(col3,0) FROM t1;
 
 ----
 
-#### 5.5.4 NVL
+#### 5.5.5 NVL
 
 **Description**
 
@@ -2055,7 +2101,7 @@ SELECT col2, NVL(col1,'IS NULL') "nvl" FROM t1;
 
 ----
 
-#### 5.5.5 NVL2
+#### 5.5.6 NVL2
 
 **Description**
 

--- a/expected/orafce.out
+++ b/expected/orafce.out
@@ -4400,3 +4400,178 @@ SELECT oracle.unistr('wrong: \U0000db99\U00000061');
 ERROR:  invalid Unicode surrogate pair
 SELECT oracle.unistr('wrong: \U002FFFFF');
 ERROR:  invalid Unicode escape value
+----
+-- Tests for the greatest/least scalar function
+----
+-- The PostgreSQL native function returns NULL only if all parameters are nulls
+SELECT greatest(2, 6, 8);
+ greatest 
+----------
+        8
+(1 row)
+
+SELECT greatest(2, NULL, 8);
+ greatest 
+----------
+        8
+(1 row)
+
+SELECT least(2, 6, 8);
+ least 
+-------
+     2
+(1 row)
+
+SELECT least(2, NULL, 8);
+ least 
+-------
+     2
+(1 row)
+
+-- The Oracle function returns NULL on NULL input, even a single parameter
+SELECT oracle.greatest(2, 6, 8, 4);
+ greatest 
+----------
+        8
+(1 row)
+
+SELECT oracle.greatest(2, NULL, 8, 4);
+ greatest 
+----------
+      ***
+(1 row)
+
+SELECT oracle.least(2, 6, 8, 1);
+ least 
+-------
+     1
+(1 row)
+
+SELECT oracle.least(2, NULL, 8, 1);
+ least 
+-------
+   ***
+(1 row)
+
+-- Both don't like data type mix
+SELECT greatest(2, 'A', 'B', 'C');
+ERROR:  invalid input syntax for type integer: "A"
+LINE 1: SELECT greatest(2, 'A', 'B', 'C');
+                           ^
+SELECT oracle.greatest(2, 'A', 'B', 'C');
+ERROR:  invalid input syntax for type integer: "A"
+LINE 1: SELECT oracle.greatest(2, 'A', 'B', 'C');
+                                  ^
+SELECT greatest('A', 'B', '1', '2');
+ greatest 
+----------
+ B
+(1 row)
+
+SELECT oracle.greatest('A', 'B', '1', '2');
+ERROR:  could not determine polymorphic type because input has type unknown
+SELECT greatest('A', 'B', 1, 2);
+ERROR:  invalid input syntax for type integer: "A"
+LINE 1: SELECT greatest('A', 'B', 1, 2);
+                        ^
+SELECT oracle.greatest('A', 'B', 1, 2);
+ERROR:  invalid input syntax for type integer: "A"
+LINE 1: SELECT oracle.greatest('A', 'B', 1, 2);
+                               ^
+-- Test different data type
+SELECT oracle.greatest('A'::text, 'B'::text, 'C'::text, 'D'::text);
+ greatest 
+----------
+ D
+(1 row)
+
+SELECT oracle.greatest('A'::bpchar, 'B'::bpchar, 'C'::bpchar, 'D'::bpchar);
+ greatest 
+----------
+ D
+(1 row)
+
+SELECT oracle.greatest(1::bigint,2::bigint,3::bigint,4::bigint);
+ greatest 
+----------
+        4
+(1 row)
+
+SELECT oracle.greatest(1::integer,2::integer,3::integer,4::integer);
+ greatest 
+----------
+        4
+(1 row)
+
+SELECT oracle.greatest(1::smallint,2::smallint,3::smallint,4::smallint);
+ greatest 
+----------
+        4
+(1 row)
+
+SELECT oracle.greatest(1.2::numeric,2.4::numeric,2.3::numeric,2.2::numeric);
+ greatest 
+----------
+      2.4
+(1 row)
+
+SELECT oracle.greatest(1.2::double precision,2.4::double precision,2.3::double precision,2.2::double precision);
+ greatest 
+----------
+      2.4
+(1 row)
+
+SELECT oracle.greatest(1.2::real,2.4::real,2.2::real,2.3::real);
+ greatest 
+----------
+      2.4
+(1 row)
+
+SELECT oracle.least('A'::text, 'B'::text, 'C'::text, 'D'::text);
+ least 
+-------
+ A
+(1 row)
+
+SELECT oracle.least('A'::bpchar, 'B'::bpchar, 'C'::bpchar, 'D'::bpchar);
+ least 
+-------
+ A
+(1 row)
+
+SELECT oracle.least(1::bigint,2::bigint,3::bigint,4::bigint);
+ least 
+-------
+     1
+(1 row)
+
+SELECT oracle.least(1::integer,2::integer,3::integer,4::integer);
+ least 
+-------
+     1
+(1 row)
+
+SELECT oracle.least(1::smallint,2::smallint,3::smallint,4::smallint);
+ least 
+-------
+     1
+(1 row)
+
+SELECT oracle.least(1.2::numeric,2.4::numeric,2.3::numeric,2.2::numeric);
+ least 
+-------
+   1.2
+(1 row)
+
+SELECT oracle.least(1.2::double precision,2.4::double precision,2.3::double precision,2.2::double precision);
+ least 
+-------
+   1.2
+(1 row)
+
+SELECT oracle.least(1.2::real,2.4::real,2.2::real,2.3::real);
+ least 
+-------
+   1.2
+(1 row)
+

--- a/orafce--3.17--3.18.sql
+++ b/orafce--3.17--3.18.sql
@@ -16,6 +16,18 @@ AS
 'SELECT greatest($1, $2, $3)'
 LANGUAGE SQL STRICT IMMUTABLE;
 
+CREATE FUNCTION oracle.greatest(smallint, smallint)
+RETURNS smallint
+AS
+'SELECT greatest($1, $2)'
+LANGUAGE SQL STRICT IMMUTABLE;
+
+CREATE FUNCTION oracle.greatest(smallint, smallint, smallint)
+RETURNS smallint
+AS
+'SELECT greatest($1, $2, $3)'
+LANGUAGE SQL STRICT IMMUTABLE;
+
 CREATE FUNCTION oracle.greatest(numeric, numeric)
 RETURNS numeric
 AS
@@ -126,6 +138,18 @@ LANGUAGE SQL STRICT IMMUTABLE;
 
 CREATE FUNCTION oracle.least(integer, integer, integer)
 RETURNS integer
+AS
+'SELECT least($1, $2, $3)'
+LANGUAGE SQL STRICT IMMUTABLE;
+
+CREATE FUNCTION oracle.least(smallint, smallint)
+RETURNS smallint
+AS
+'SELECT least($1, $2)'
+LANGUAGE SQL STRICT IMMUTABLE;
+
+CREATE FUNCTION oracle.least(smallint, smallint, smallint)
+RETURNS smallint
 AS
 'SELECT least($1, $2, $3)'
 LANGUAGE SQL STRICT IMMUTABLE;

--- a/orafce--3.17--3.18.sql
+++ b/orafce--3.17--3.18.sql
@@ -1,0 +1,232 @@
+----
+-- Add LEAST/GREATEST declaration to return NULL on NULL input.
+-- PostgreSQL only returns NULL when all the parameters are NULL.
+----
+
+-- GREATEST
+CREATE FUNCTION oracle.greatest(integer, integer)
+RETURNS integer
+AS
+'SELECT greatest($1, $2)'
+LANGUAGE SQL STRICT IMMUTABLE;
+
+CREATE FUNCTION oracle.greatest(integer, integer, integer)
+RETURNS integer
+AS
+'SELECT greatest($1, $2, $3)'
+LANGUAGE SQL STRICT IMMUTABLE;
+
+CREATE FUNCTION oracle.greatest(numeric, numeric)
+RETURNS numeric
+AS
+'SELECT greatest($1, $2)'
+LANGUAGE SQL STRICT IMMUTABLE;
+
+CREATE FUNCTION oracle.greatest(numeric, numeric, numeric)
+RETURNS numeric
+AS
+'SELECT greatest($1, $2, $3)'
+LANGUAGE SQL STRICT IMMUTABLE;
+
+CREATE FUNCTION oracle.greatest(bigint, bigint)
+RETURNS bigint
+AS
+'SELECT greatest($1, $2)'
+LANGUAGE SQL STRICT IMMUTABLE;
+
+CREATE FUNCTION oracle.greatest(bigint, bigint, bigint)
+RETURNS bigint
+AS
+'SELECT greatest($1, $2, $3)'
+LANGUAGE SQL STRICT IMMUTABLE;
+
+CREATE FUNCTION oracle.greatest(bpchar, bpchar)
+RETURNS bpchar
+AS
+'SELECT greatest($1, $2)'
+LANGUAGE SQL STRICT IMMUTABLE;
+
+CREATE FUNCTION oracle.greatest(bpchar, bpchar, bpchar)
+RETURNS bpchar
+AS
+'SELECT greatest($1, $2, $3)'
+LANGUAGE SQL STRICT IMMUTABLE;
+
+CREATE FUNCTION oracle.greatest(text, text)
+RETURNS text
+AS
+'SELECT greatest($1, $2)'
+LANGUAGE SQL STRICT IMMUTABLE;
+
+CREATE FUNCTION oracle.greatest(text, text, text)
+RETURNS text
+AS
+'SELECT greatest($1, $2, $3)'
+LANGUAGE SQL STRICT IMMUTABLE;
+
+CREATE FUNCTION oracle.greatest(date, date)
+RETURNS date
+AS
+'SELECT greatest($1, $2)'
+LANGUAGE SQL STRICT IMMUTABLE;
+
+CREATE FUNCTION oracle.greatest(date, date, date)
+RETURNS date
+AS
+'SELECT greatest($1, $2, $3)'
+LANGUAGE SQL STRICT IMMUTABLE;
+
+CREATE FUNCTION oracle.greatest(time, time)
+RETURNS time
+AS
+'SELECT greatest($1, $2)'
+LANGUAGE SQL STRICT IMMUTABLE;
+
+CREATE FUNCTION oracle.greatest(time, time, time)
+RETURNS time
+AS
+'SELECT greatest($1, $2, $3)'
+LANGUAGE SQL STRICT IMMUTABLE;
+
+CREATE FUNCTION oracle.greatest(timestamp, timestamp)
+RETURNS timestamp
+AS
+'SELECT greatest($1, $2)'
+LANGUAGE SQL STRICT IMMUTABLE;
+
+CREATE FUNCTION oracle.greatest(timestamp, timestamp, timestamp)
+RETURNS timestamp
+AS
+'SELECT greatest($1, $2, $3)'
+LANGUAGE SQL STRICT IMMUTABLE;
+
+CREATE FUNCTION oracle.greatest(timestamptz, timestamptz)
+RETURNS timestamptz
+AS
+'SELECT greatest($1, $2)'
+LANGUAGE SQL STRICT IMMUTABLE;
+
+CREATE FUNCTION oracle.greatest(timestamptz, timestamptz, timestamptz)
+RETURNS timestamptz
+AS
+'SELECT greatest($1, $2, $3)'
+LANGUAGE SQL STRICT IMMUTABLE;
+
+CREATE FUNCTION oracle.greatest(anynonarray, VARIADIC anyarray)
+RETURNS anynonarray
+AS 'MODULE_PATHNAME', 'ora_greatest'
+LANGUAGE C IMMUTABLE;
+
+-- LEAST
+CREATE FUNCTION oracle.least(integer, integer)
+RETURNS integer
+AS
+'SELECT least($1, $2)'
+LANGUAGE SQL STRICT IMMUTABLE;
+
+CREATE FUNCTION oracle.least(integer, integer, integer)
+RETURNS integer
+AS
+'SELECT least($1, $2, $3)'
+LANGUAGE SQL STRICT IMMUTABLE;
+
+CREATE FUNCTION oracle.least(numeric, numeric)
+RETURNS numeric
+AS
+'SELECT least($1, $2)'
+LANGUAGE SQL STRICT IMMUTABLE;
+
+CREATE FUNCTION oracle.least(numeric, numeric, numeric)
+RETURNS numeric
+AS
+'SELECT least($1, $2, $3)'
+LANGUAGE SQL STRICT IMMUTABLE;
+
+CREATE FUNCTION oracle.least(bigint, bigint)
+RETURNS bigint
+AS
+'SELECT least($1, $2)'
+LANGUAGE SQL STRICT IMMUTABLE;
+
+CREATE FUNCTION oracle.least(bigint, bigint, bigint)
+RETURNS bigint
+AS
+'SELECT least($1, $2, $3)'
+LANGUAGE SQL STRICT IMMUTABLE;
+
+CREATE FUNCTION oracle.least(bpchar, bpchar)
+RETURNS bpchar
+AS
+'SELECT least($1, $2)'
+LANGUAGE SQL STRICT IMMUTABLE;
+
+CREATE FUNCTION oracle.least(bpchar, bpchar, bpchar)
+RETURNS bpchar
+AS
+'SELECT least($1, $2, $3)'
+LANGUAGE SQL STRICT IMMUTABLE;
+
+CREATE FUNCTION oracle.least(text, text)
+RETURNS text
+AS
+'SELECT least($1, $2)'
+LANGUAGE SQL STRICT IMMUTABLE;
+
+CREATE FUNCTION oracle.least(text, text, text)
+RETURNS text
+AS
+'SELECT least($1, $2, $3)'
+LANGUAGE SQL STRICT IMMUTABLE;
+
+CREATE FUNCTION oracle.least(date, date)
+RETURNS date
+AS
+'SELECT least($1, $2)'
+LANGUAGE SQL STRICT IMMUTABLE;
+
+CREATE FUNCTION oracle.least(date, date, date)
+RETURNS date
+AS
+'SELECT least($1, $2, $3)'
+LANGUAGE SQL STRICT IMMUTABLE;
+
+CREATE FUNCTION oracle.least(time, time)
+RETURNS time
+AS
+'SELECT least($1, $2)'
+LANGUAGE SQL STRICT IMMUTABLE;
+
+CREATE FUNCTION oracle.least(time, time, time)
+RETURNS time
+AS
+'SELECT least($1, $2, $3)'
+LANGUAGE SQL STRICT IMMUTABLE;
+
+CREATE FUNCTION oracle.least(timestamp, timestamp)
+RETURNS timestamp
+AS
+'SELECT least($1, $2)'
+LANGUAGE SQL STRICT IMMUTABLE;
+
+CREATE FUNCTION oracle.least(timestamp, timestamp, timestamp)
+RETURNS timestamp
+AS
+'SELECT least($1, $2, $3)'
+LANGUAGE SQL STRICT IMMUTABLE;
+
+CREATE FUNCTION oracle.least(timestamptz, timestamptz)
+RETURNS timestamptz
+AS
+'SELECT least($1, $2)'
+LANGUAGE SQL STRICT IMMUTABLE;
+
+CREATE FUNCTION oracle.least(timestamptz, timestamptz, timestamptz)
+RETURNS timestamptz
+AS
+'SELECT least($1, $2, $3)'
+LANGUAGE SQL STRICT IMMUTABLE;
+
+CREATE FUNCTION oracle.least(anynonarray, VARIADIC anyarray)
+RETURNS anynonarray
+AS 'MODULE_PATHNAME', 'ora_least'
+LANGUAGE C IMMUTABLE;

--- a/orafce--3.18.sql
+++ b/orafce--3.18.sql
@@ -1,4 +1,4 @@
-/* orafce--3.17.sql */
+/* orafce--3.18.sql */
 
 -- complain if script is sourced in psql, rather than via CREATE EXTENSION
 \echo Use "CREATE EXTENSION orafce" to load this file. \quit
@@ -4242,3 +4242,236 @@ BEGIN
 END;
 $$
 LANGUAGE plpgsql;
+
+----
+-- Add LEAST/GREATEST declaration to return NULL on NULL input.
+-- PostgreSQL only returns NULL when all the parameters are NULL.
+----
+
+-- GREATEST
+CREATE FUNCTION oracle.greatest(integer, integer)
+RETURNS integer
+AS
+'SELECT greatest($1, $2)'
+LANGUAGE SQL STRICT IMMUTABLE;
+
+CREATE FUNCTION oracle.greatest(integer, integer, integer)
+RETURNS integer
+AS
+'SELECT greatest($1, $2, $3)'
+LANGUAGE SQL STRICT IMMUTABLE;
+
+CREATE FUNCTION oracle.greatest(numeric, numeric)
+RETURNS numeric
+AS
+'SELECT greatest($1, $2)'
+LANGUAGE SQL STRICT IMMUTABLE;
+
+CREATE FUNCTION oracle.greatest(numeric, numeric, numeric)
+RETURNS numeric
+AS
+'SELECT greatest($1, $2, $3)'
+LANGUAGE SQL STRICT IMMUTABLE;
+
+CREATE FUNCTION oracle.greatest(bigint, bigint)
+RETURNS bigint
+AS
+'SELECT greatest($1, $2)'
+LANGUAGE SQL STRICT IMMUTABLE;
+
+CREATE FUNCTION oracle.greatest(bigint, bigint, bigint)
+RETURNS bigint
+AS
+'SELECT greatest($1, $2, $3)'
+LANGUAGE SQL STRICT IMMUTABLE;
+
+CREATE FUNCTION oracle.greatest(bpchar, bpchar)
+RETURNS bpchar
+AS
+'SELECT greatest($1, $2)'
+LANGUAGE SQL STRICT IMMUTABLE;
+
+CREATE FUNCTION oracle.greatest(bpchar, bpchar, bpchar)
+RETURNS bpchar
+AS
+'SELECT greatest($1, $2, $3)'
+LANGUAGE SQL STRICT IMMUTABLE;
+
+CREATE FUNCTION oracle.greatest(text, text)
+RETURNS text
+AS
+'SELECT greatest($1, $2)'
+LANGUAGE SQL STRICT IMMUTABLE;
+
+CREATE FUNCTION oracle.greatest(text, text, text)
+RETURNS text
+AS
+'SELECT greatest($1, $2, $3)'
+LANGUAGE SQL STRICT IMMUTABLE;
+
+CREATE FUNCTION oracle.greatest(date, date)
+RETURNS date
+AS
+'SELECT greatest($1, $2)'
+LANGUAGE SQL STRICT IMMUTABLE;
+
+CREATE FUNCTION oracle.greatest(date, date, date)
+RETURNS date
+AS
+'SELECT greatest($1, $2, $3)'
+LANGUAGE SQL STRICT IMMUTABLE;
+
+CREATE FUNCTION oracle.greatest(time, time)
+RETURNS time
+AS
+'SELECT greatest($1, $2)'
+LANGUAGE SQL STRICT IMMUTABLE;
+
+CREATE FUNCTION oracle.greatest(time, time, time)
+RETURNS time
+AS
+'SELECT greatest($1, $2, $3)'
+LANGUAGE SQL STRICT IMMUTABLE;
+
+CREATE FUNCTION oracle.greatest(timestamp, timestamp)
+RETURNS timestamp
+AS
+'SELECT greatest($1, $2)'
+LANGUAGE SQL STRICT IMMUTABLE;
+
+CREATE FUNCTION oracle.greatest(timestamp, timestamp, timestamp)
+RETURNS timestamp
+AS
+'SELECT greatest($1, $2, $3)'
+LANGUAGE SQL STRICT IMMUTABLE;
+
+CREATE FUNCTION oracle.greatest(timestamptz, timestamptz)
+RETURNS timestamptz
+AS
+'SELECT greatest($1, $2)'
+LANGUAGE SQL STRICT IMMUTABLE;
+
+CREATE FUNCTION oracle.greatest(timestamptz, timestamptz, timestamptz)
+RETURNS timestamptz
+AS
+'SELECT greatest($1, $2, $3)'
+LANGUAGE SQL STRICT IMMUTABLE;
+
+CREATE FUNCTION oracle.greatest(anynonarray, VARIADIC anyarray)
+RETURNS anynonarray
+AS 'MODULE_PATHNAME', 'ora_greatest'
+LANGUAGE C IMMUTABLE;
+
+-- LEAST
+CREATE FUNCTION oracle.least(integer, integer)
+RETURNS integer
+AS
+'SELECT least($1, $2)'
+LANGUAGE SQL STRICT IMMUTABLE;
+
+CREATE FUNCTION oracle.least(integer, integer, integer)
+RETURNS integer
+AS
+'SELECT least($1, $2, $3)'
+LANGUAGE SQL STRICT IMMUTABLE;
+
+CREATE FUNCTION oracle.least(numeric, numeric)
+RETURNS numeric
+AS
+'SELECT least($1, $2)'
+LANGUAGE SQL STRICT IMMUTABLE;
+
+CREATE FUNCTION oracle.least(numeric, numeric, numeric)
+RETURNS numeric
+AS
+'SELECT least($1, $2, $3)'
+LANGUAGE SQL STRICT IMMUTABLE;
+
+CREATE FUNCTION oracle.least(bigint, bigint)
+RETURNS bigint
+AS
+'SELECT least($1, $2)'
+LANGUAGE SQL STRICT IMMUTABLE;
+
+CREATE FUNCTION oracle.least(bigint, bigint, bigint)
+RETURNS bigint
+AS
+'SELECT least($1, $2, $3)'
+LANGUAGE SQL STRICT IMMUTABLE;
+
+CREATE FUNCTION oracle.least(bpchar, bpchar)
+RETURNS bpchar
+AS
+'SELECT least($1, $2)'
+LANGUAGE SQL STRICT IMMUTABLE;
+
+CREATE FUNCTION oracle.least(bpchar, bpchar, bpchar)
+RETURNS bpchar
+AS
+'SELECT least($1, $2, $3)'
+LANGUAGE SQL STRICT IMMUTABLE;
+
+CREATE FUNCTION oracle.least(text, text)
+RETURNS text
+AS
+'SELECT least($1, $2)'
+LANGUAGE SQL STRICT IMMUTABLE;
+
+CREATE FUNCTION oracle.least(text, text, text)
+RETURNS text
+AS
+'SELECT least($1, $2, $3)'
+LANGUAGE SQL STRICT IMMUTABLE;
+
+CREATE FUNCTION oracle.least(date, date)
+RETURNS date
+AS
+'SELECT least($1, $2)'
+LANGUAGE SQL STRICT IMMUTABLE;
+
+CREATE FUNCTION oracle.least(date, date, date)
+RETURNS date
+AS
+'SELECT least($1, $2, $3)'
+LANGUAGE SQL STRICT IMMUTABLE;
+
+CREATE FUNCTION oracle.least(time, time)
+RETURNS time
+AS
+'SELECT least($1, $2)'
+LANGUAGE SQL STRICT IMMUTABLE;
+
+CREATE FUNCTION oracle.least(time, time, time)
+RETURNS time
+AS
+'SELECT least($1, $2, $3)'
+LANGUAGE SQL STRICT IMMUTABLE;
+
+CREATE FUNCTION oracle.least(timestamp, timestamp)
+RETURNS timestamp
+AS
+'SELECT least($1, $2)'
+LANGUAGE SQL STRICT IMMUTABLE;
+
+CREATE FUNCTION oracle.least(timestamp, timestamp, timestamp)
+RETURNS timestamp
+AS
+'SELECT least($1, $2, $3)'
+LANGUAGE SQL STRICT IMMUTABLE;
+
+CREATE FUNCTION oracle.least(timestamptz, timestamptz)
+RETURNS timestamptz
+AS
+'SELECT least($1, $2)'
+LANGUAGE SQL STRICT IMMUTABLE;
+
+CREATE FUNCTION oracle.least(timestamptz, timestamptz, timestamptz)
+RETURNS timestamptz
+AS
+'SELECT least($1, $2, $3)'
+LANGUAGE SQL STRICT IMMUTABLE;
+
+CREATE FUNCTION oracle.least(anynonarray, VARIADIC anyarray)
+RETURNS anynonarray
+AS 'MODULE_PATHNAME', 'ora_least'
+LANGUAGE C IMMUTABLE;

--- a/orafce--3.18.sql
+++ b/orafce--3.18.sql
@@ -4261,6 +4261,18 @@ AS
 'SELECT greatest($1, $2, $3)'
 LANGUAGE SQL STRICT IMMUTABLE;
 
+CREATE FUNCTION oracle.greatest(smallint, smallint)
+RETURNS smallint
+AS
+'SELECT greatest($1, $2)'
+LANGUAGE SQL STRICT IMMUTABLE;
+
+CREATE FUNCTION oracle.greatest(smallint, smallint, smallint)
+RETURNS smallint
+AS
+'SELECT greatest($1, $2, $3)'
+LANGUAGE SQL STRICT IMMUTABLE;
+
 CREATE FUNCTION oracle.greatest(numeric, numeric)
 RETURNS numeric
 AS
@@ -4371,6 +4383,18 @@ LANGUAGE SQL STRICT IMMUTABLE;
 
 CREATE FUNCTION oracle.least(integer, integer, integer)
 RETURNS integer
+AS
+'SELECT least($1, $2, $3)'
+LANGUAGE SQL STRICT IMMUTABLE;
+
+CREATE FUNCTION oracle.least(smallint, smallint)
+RETURNS smallint
+AS
+'SELECT least($1, $2)'
+LANGUAGE SQL STRICT IMMUTABLE;
+
+CREATE FUNCTION oracle.least(smallint, smallint, smallint)
+RETURNS smallint
 AS
 'SELECT least($1, $2, $3)'
 LANGUAGE SQL STRICT IMMUTABLE;

--- a/orafce.control
+++ b/orafce.control
@@ -1,5 +1,5 @@
 # orafce extension
 comment = 'Functions and operators that emulate a subset of functions and packages from the Oracle RDBMS'
-default_version = '3.17'
+default_version = '3.18'
 module_pathname = '$libdir/orafce'
 relocatable = false

--- a/sql/orafce.sql
+++ b/sql/orafce.sql
@@ -1031,3 +1031,43 @@ SELECT oracle.unistr('wrong: \+2FFFFF');
 SELECT oracle.unistr('wrong: \udb99\u0061');
 SELECT oracle.unistr('wrong: \U0000db99\U00000061');
 SELECT oracle.unistr('wrong: \U002FFFFF');
+----
+-- Tests for the greatest/least scalar function
+----
+-- The PostgreSQL native function returns NULL only if all parameters are nulls
+SELECT greatest(2, 6, 8);
+SELECT greatest(2, NULL, 8);
+SELECT least(2, 6, 8);
+SELECT least(2, NULL, 8);
+
+-- The Oracle function returns NULL on NULL input, even a single parameter
+SELECT oracle.greatest(2, 6, 8, 4);
+SELECT oracle.greatest(2, NULL, 8, 4);
+SELECT oracle.least(2, 6, 8, 1);
+SELECT oracle.least(2, NULL, 8, 1);
+
+-- Both don't like data type mix
+SELECT greatest(2, 'A', 'B', 'C');
+SELECT oracle.greatest(2, 'A', 'B', 'C');
+SELECT greatest('A', 'B', '1', '2');
+SELECT oracle.greatest('A', 'B', '1', '2');
+SELECT greatest('A', 'B', 1, 2);
+SELECT oracle.greatest('A', 'B', 1, 2);
+
+-- Test different data type
+SELECT oracle.greatest('A'::text, 'B'::text, 'C'::text, 'D'::text);
+SELECT oracle.greatest('A'::bpchar, 'B'::bpchar, 'C'::bpchar, 'D'::bpchar);
+SELECT oracle.greatest(1::bigint,2::bigint,3::bigint,4::bigint);
+SELECT oracle.greatest(1::integer,2::integer,3::integer,4::integer);
+SELECT oracle.greatest(1::smallint,2::smallint,3::smallint,4::smallint);
+SELECT oracle.greatest(1.2::numeric,2.4::numeric,2.3::numeric,2.2::numeric);
+SELECT oracle.greatest(1.2::double precision,2.4::double precision,2.3::double precision,2.2::double precision);
+SELECT oracle.greatest(1.2::real,2.4::real,2.2::real,2.3::real);
+SELECT oracle.least('A'::text, 'B'::text, 'C'::text, 'D'::text);
+SELECT oracle.least('A'::bpchar, 'B'::bpchar, 'C'::bpchar, 'D'::bpchar);
+SELECT oracle.least(1::bigint,2::bigint,3::bigint,4::bigint);
+SELECT oracle.least(1::integer,2::integer,3::integer,4::integer);
+SELECT oracle.least(1::smallint,2::smallint,3::smallint,4::smallint);
+SELECT oracle.least(1.2::numeric,2.4::numeric,2.3::numeric,2.2::numeric);
+SELECT oracle.least(1.2::double precision,2.4::double precision,2.3::double precision,2.2::double precision);
+SELECT oracle.least(1.2::real,2.4::real,2.2::real,2.3::real);


### PR DESCRIPTION
Oracle functions LEAST and GREATEST return NULL if at least one of the parameters is NULL. This is not the case for the PostgreSQL equivalent functions which only return NULL when all the parameters are NULL. This patch creates the two functions in the oracle schema to have the same behavior than in Oracle.

The greatest and least functions are redefined in schema oracle using a C function. They are also SQL functions redefinition with two and three parameters of most common data type using the STRICT attribute so that most common call can be fast and inlined.