### PR TITLE
Fix typos and spelling in docs and error messages

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -9,7 +9,7 @@ The Orafce is supported in https://aws.amazon.com/about-aws/whats-new/2018/03/am
 == Oracle functions and Oracle packages
 
 This module contains some useful functions that can help with porting
-Oracle application to PostgreSQL or that can be generally useful. 
+Oracle application to PostgreSQL or that can be generally useful.
 
 Built-in Oracle date functions have been tested against Oracle 10 for
 conformance. Date ranges from 1960 to 2070 work correctly. Dates before
@@ -61,7 +61,7 @@ year. The 16th of July will be rounded to August.
 ----
 	next_day(date '2005-05-24', 1) -> 2005-05-30
 ----
-* months_between(date, date) numeric - Returns the number of months between date1 and date2. If a fractional month is calculated, the months_between  function calculates the fraction based on a 31-day month. 
+* months_between(date, date) numeric - Returns the number of months between date1 and date2. If a fractional month is calculated, the months_between  function calculates the fraction based on a 31-day month.
 +
 ----
 	months_between(date '1995-02-02', date '1995-01-01') -> 1.0322580645161
@@ -237,8 +237,8 @@ used by Oracle users, it has been added in orafce.
 == Package dbms_output
 
 PostgreSQL sends information to the client via RAISE NOTICE. Oracle uses
-dbms_output.put_line(). This works differently from RAISE NOTICE. Oracle has 
-a session queue, put_line() adds a line to the queue and the function 
+dbms_output.put_line(). This works differently from RAISE NOTICE. Oracle has
+a session queue, put_line() adds a line to the queue and the function
 get_line() reads from queue. If flag 'serveroutput' is set, then client
 over all sql statements reads queue. You can use:
 
@@ -248,7 +248,7 @@ over all sql statements reads queue. You can use:
     select dbms_output.put_line('next_line');
     select * from dbms_output.get_lines(0);
 ----
-    
+
 or
 
 ----
@@ -256,9 +256,9 @@ or
     select dbms_output.serveroutput('t');
     select dbms_output.put_line('first_line');
 ----
-    
-This package contains the following functions: enable(), disable(), 
-serveroutput(), put(), put_line(), new_line(), get_line(), get_lines(). 
+
+This package contains the following functions: enable(), disable(),
+serveroutput(), put(), put_line(), new_line(), get_line(), get_lines().
 The package queue is implemented in the session's local memory.
 
 == Package utl_file
@@ -281,7 +281,7 @@ line size is 32K. This package contains following functions:
 * utl_file.new_line(file utl_file.file_type [,rows int])  - puts some new line chars to file
 * utl_file.put(file utl_file.file_type, buffer text)  - puts buffer to file
 * utl_file.put_line(file utl_file.file_type, buffer text)  - puts line to file
-* utl_file.putf(file utl_file.file_type, format buffer [,arg1 text][,arg2 text][..][,arg5 text])  - put formated text into file
+* utl_file.putf(file utl_file.file_type, format buffer [,arg1 text][,arg2 text][..][,arg5 text])  - put formatted text into file
 * utl_file.tmpdir() - get path of temp directory
 
 Because PostgreSQL doesn't support call by reference, some functions are slightly different:
@@ -324,7 +324,7 @@ or second (with PostgreSQL specific function get_nextline)
 
 Before using the package you have to set the utl_file.utl_file_dir table.
 It contains all allowed directories without ending symbol ('/' or '\').
-On WinNT platform, the paths have to end with symbol '\' everytime.
+On WinNT platform, the paths have to end with symbol '\' every time.
 
 Directory entries can be named (second column in table `utl_file.utl_file_dir`).
 The `location` parameter can be either the directory name or the dictionary path.
@@ -341,10 +341,10 @@ utl_file.utl_file_dir table). The content of this table is visible for PUBLIC
 
 == Package dbms_pipe
 
-This package is an emulation of dbms_pipe Oracle package. It provides 
-inter-session comunication. You can send and read any message with or without 
-waiting; list active pipes; set a pipe as private or public; and, use 
-explicit or implicit pipes. 
+This package is an emulation of dbms_pipe Oracle package. It provides
+inter-session communication. You can send and read any message with or without
+waiting; list active pipes; set a pipe as private or public; and, use
+explicit or implicit pipes.
 
 The maximum number of pipes is 50.
 
@@ -402,8 +402,8 @@ package PLVdate. Detailed documentation can be found in PLVision library.
 This package is multicultural, but default configurations are only for
 european countries (see source code).
 
-You should define your own non-business days (max 50 days) and own 
-holidays (max 30 days). A holiday is any non-business day, which is the same 
+You should define your own non-business days (max 50 days) and own
+holidays (max 30 days). A holiday is any non-business day, which is the same
 every year. For example, Christmas day in Western countries.
 
 === Functions
@@ -498,16 +498,16 @@ List of functions:
 * plvstr.rpart(str text, div text, start int, nth int) - Call this function to return the right part of a string
 * plvstr.rpart(str text, div text, start int)          - Call this function to return the right part of a string
 * plvstr.rpart(str text, div text)                     - Call this function to return the right part of a string
-* plvstr.lstrip(str text, substr text, num int) - Call this function to remove characters from the beginning 
-* plvstr.lstrip(str text, substr text)          - Call this function to remove characters from the beginning 
+* plvstr.lstrip(str text, substr text, num int) - Call this function to remove characters from the beginning
+* plvstr.lstrip(str text, substr text)          - Call this function to remove characters from the beginning
 * plvstr.rstrip(str text, substr text, num int) - Call this function to remove characters from the end
 * plvstr.rstrip(str text, substr text)          - Call this function to remove characters from the end
 * plvstr.rvrs(str text, start int, _end int) - Reverse string or part of string
 * plvstr.rvrs(str text, start int)           - Reverse string or part of string
 * plvstr.rvrs(str text)                      - Reverse string or part of string
-* plvstr.left(str text, n int)  -  Returns firs num_in charaters. You can use negative num_in
-* plvstr.right(str text, n int) - Returns last num_in charaters. You can use negative num_ni
-* plvstr.swap(str text, replace text, start int, lengh int) - Replace a substring in a string with a specified string
+* plvstr.left(str text, n int)  -  Returns firs num_in characters. You can use negative num_in
+* plvstr.right(str text, n int) - Returns last num_in characters. You can use negative num_ni
+* plvstr.swap(str text, replace text, start int, length int) - Replace a substring in a string with a specified string
 * plvstr.swap(str text, replace text)                       - Replace a substring in a string with a specified string
 * plvstr.betwn(str text, start int, _end int, inclusive bool) - Find the Substring Between Start and End Locations
 * plvstr.betwn(str text, start text, _end text, startnth int, endnth int, inclusive bool, gotoend bool) - Find the Substring Between Start and End Locations
@@ -518,8 +518,8 @@ List of functions:
 * plvchr.last(str text)       - Call this function to return the last character in a string
 * plvchr.is_blank(c int)  - Is blank
 * plvchr.is_blank(c text) - Is blank
-* plvchr.is_digit(c int)  - Is digit 
-* plvchr.is_digit(c text) - Is digit 
+* plvchr.is_digit(c int)  - Is digit
+* plvchr.is_digit(c text) - Is digit
 * plvchr.is_quote(c int)  - Is quote
 * plvchr.is_quote(c text) - Is quote
 * plvchr.is_other(c int)  - Is other
@@ -534,14 +534,14 @@ List of functions:
 
 == Package PLVsubst
 
-The PLVsubst package performs string substitutions based on a substitution keyword. 
+The PLVsubst package performs string substitutions based on a substitution keyword.
 
 * plvsubst.string(template_in text, vals_in text[])                 - Scans a string for all instances of the substitution keyword and replace it with the next value in the substitution values list
 * plvsubst.string(template_in text, vals_in text[], subst_in text)
 * plvsubst.string(template_in text, vals_in text, delim_in text)
 * plvsubst.string(template_in text, vals_in text, delim_in text, subst_in text)
 * plvsubst.setsubst(str text) - Set substitution keyword to default '%s'
-* plvsubst.subst() - Retrieve substitution keyword 
+* plvsubst.subst() - Retrieve substitution keyword
 
 Examples:
 
@@ -586,7 +586,7 @@ postgres=# select foo2();
 
 == Package PLVlex
 
-This package isn't compatible with original PLVlex. 
+This package isn't compatible with original PLVlex.
 
 ----
 postgres=# select * from 
@@ -608,7 +608,7 @@ postgres=# select * from
 ----
 
 Warning: Keyword's codes can be changed between PostgreSQL versions!
-o plvlex.tokens(str text, skip_spaces bool, qualified_names bool) - Returns table of lexical elements in str. 
+o plvlex.tokens(str text, skip_spaces bool, qualified_names bool) - Returns table of lexical elements in str.
 
 == DBMS_SQL
 In this time this package is in independent project https://github.com/okbob/dbms_sql . It introduces a procedures - that are supported by PostgreSQL 11. Orafce runs on PostgreSQL 9.5, so it is not possible to merge DBMS_SQL into Orafce now. If you have PostgreSQL 11 and higher, then you can use DBMS_SQL and Orafce together.
@@ -623,19 +623,19 @@ This package protects user input against SQL injection.
 * dbms_assert.qualified_sql_name(varchar) varchar - This function verifies that the input string is qualified SQL name.
 * dbms_assert.schema_name(varchar) varchar - Function verifies that input string is an existing schema name.
 * dbms_assert.simple_sql_name(varchar) varchar -This function verifies that the input string is simple SQL name.
-* dbms_assert.object_name(varchar) varchar - Verifies that input string is qualified SQL identifier of an existing SQL object. 
+* dbms_assert.object_name(varchar) varchar - Verifies that input string is qualified SQL identifier of an existing SQL object.
 
 == PLUnit
 
 This unit contains some assert functions.
 
-* plunit.assert_true(bool [, varchar]) - 		Asserts that the condition is true. 
-* plunit.assert_false(bool [, varchar]) - 		Asserts that the condition is false. 
+* plunit.assert_true(bool [, varchar]) - 		Asserts that the condition is true.
+* plunit.assert_false(bool [, varchar]) - 		Asserts that the condition is false.
 * plunit.assert_null(anyelement [, varchar]) -		Asserts that the actual is null.
 * plunit.assert_not_null(anyelement [, varchar]) - 	Asserts that the actual isn't null.
-* plunit.assert_equals(anyelement, anyelement [, double precision] [, varchar]) - Asserts that expected and actual are equal. 
-* plunit.assert_not_equals(anyelement, anyelement [, double precision] [, varchar]) - Asserts that expected and actual are equal. 
-* plunit.fail([varchar]) -				Fail can be used to cause a test procedure to fail immediately using the supplied message. 
+* plunit.assert_equals(anyelement, anyelement [, double precision] [, varchar]) - Asserts that expected and actual are equal.
+* plunit.assert_not_equals(anyelement, anyelement [, double precision] [, varchar]) - Asserts that expected and actual are equal.
+* plunit.fail([varchar]) -				Fail can be used to cause a test procedure to fail immediately using the supplied message.
 
 == Package DBMS_random
 
@@ -646,7 +646,7 @@ This unit contains some assert functions.
 * dbms_random.seed(text) - Reset seed value.
 * dbms_random.string(opt text(1), len int) - Create random string
 * dbms_random.terminate() - Terminate package (do nothing in Pg)
-* dbms_random.value() - Returns a random number from [0.0 - 1.0) 
+* dbms_random.value() - Returns a random number from [0.0 - 1.0)
 * dbms_random.value(low double precision, high double precision) - Returns a random number from [low - high)
 
 == Others functions
@@ -685,7 +685,7 @@ Functions oracle.decode, oracle.greatest and oracle.least must always be prefixe
 
 Note that in case of lpad and rpad, parameters string and fill can be of types CHAR, VARCHAR, TEXT, VARCHAR2 or NVARCHAR2 (note that the last two are orafce-provided types). The default fill character is a half-width space. Similarly for ltrim, rtrim and btrim.
 
-Note that oracle.length has a limitation that it works only in units of characters because PostgreSQL CHAR type only supports character semantics. 
+Note that oracle.length has a limitation that it works only in units of characters because PostgreSQL CHAR type only supports character semantics.
 
 == VARCHAR2 and NVARCHAR2 Support
 
@@ -782,13 +782,13 @@ INSERT INTO test(name, surname) VALUES('', 'Stehule');
 
 == TODO
 
-* better documentation                                             
-* better seralization in dbms_pipe (via _send and _recv functions) 
+* better documentation
+* better seralization in dbms_pipe (via _send and _recv functions)
 * alter shared memory structures by temporary tables: only locks are in shmem, (bitmaps), data in tmp tbl
 
 == License
 
-This module is released under BSD licence. 
+This module is released under BSD licence.
 
 == Contributors
 

--- a/file.c
+++ b/file.c
@@ -282,7 +282,7 @@ utl_file_fopen(PG_FUNCTION_ARGS)
 		ereport(ERROR,
 		    (errcode(ERRCODE_PROGRAM_LIMIT_EXCEEDED),
 		     errmsg("program limit exceeded"),
-		     errdetail("Too much concurent opened files"),
+		     errdetail("Too many files opened concurrently"),
 		     errhint("You can only open a maximum of ten files for each session")));
 	}
 

--- a/shmmc.c
+++ b/shmmc.c
@@ -276,7 +276,7 @@ ora_sfree(void* ptr)
 			(errcode(ERRCODE_INTERNAL_ERROR),
 			 errmsg("corrupted pointer"),
 			 errdetail("Failed while reallocating memory block in shared memory."),
-			 errhint("Report this bug to autors.")));
+			 errhint("Please report this bug to the package authors.")));
 }
 
 
@@ -300,7 +300,7 @@ ora_srealloc(void *ptr, size_t size)
 			(errcode(ERRCODE_INTERNAL_ERROR),
 			errmsg("corrupted pointer"),
 			errdetail("Failed while reallocating memory block in shared memory."),
-			errhint("Report this bug to autors.")));
+			errhint("Please report this bug to the package authors.")));
 
 
 	if (NULL != (result = ora_salloc(size)))


### PR DESCRIPTION
Also in passing, remove whitespace at end of lines in the documentation.