### PR TITLE
Fix dbms_utility.get_time() to use the full range of int32.

### DIFF
--- a/utility.c
+++ b/utility.c
@@ -223,5 +223,5 @@ dbms_utility_get_time(PG_FUNCTION_ARGS)
 	struct timeval tv;
 
 	gettimeofday(&tv,NULL);
-	PG_RETURN_INT32((int32) (tv.tv_sec*1000000+tv.tv_usec)/10000);
+	PG_RETURN_INT32((int32) ((int64) tv.tv_sec * 100 + tv.tv_usec / 10000));
 }


### PR DESCRIPTION
get_time() converted microseconds since epoch to int32 and then divided by 10^4
to get centiseconds.  This computation gave a narrow range of [-214749, 214748]
that overflowed every 72 minutes or so.  Use int64 for intermediate values to
get the full range of int32 and make seeing an overflow less likely.