### PR TITLE
Fix read past the end of string in to_sigle_byte().

### DIFF
--- a/convert.c
+++ b/convert.c
@@ -536,7 +536,7 @@ orafce_to_single_byte(PG_FUNCTION_ARGS)
 	dst = (text *) palloc0(VARHDRSZ + srclen);
 	d = VARDATA(dst);
 
-	while (*s && (s - VARDATA_ANY(src) < srclen))
+	while (s - VARDATA_ANY(src) < srclen)
 	{
 		char   *u = s;
 		int		clen;


### PR DESCRIPTION
The loop over the bytes of a string in to_single_byte() read the next byte to
check it's not zero before testing for the end of string.  But a string of type
text is not zero-terminated, so this loop read past the end of string.  Unlike
bytea, text cannot contain zero bytes, so just drop this check.

Found via Valgrind testing.