### PR TITLE
Limit nlssort test to Linux/glibc systems with en_US.utf8 installed.

### DIFF
--- a/expected/nlssort.out
+++ b/expected/nlssort.out
@@ -1,4 +1,12 @@
 -- Tests for nlssort
+-- Skip this test unless it's a Linux/glibc system with the "en_US.utf8" locale installed.
+SELECT getdatabaseencoding() <> 'UTF8' OR
+       NOT EXISTS (SELECT 1 FROM pg_collation WHERE collname = 'en_US' AND collencoding = pg_char_to_encoding('UTF8')) OR
+       version() !~ 'linux-gnu'
+       AS skip_test \gset
+\if :skip_test
+\quit
+\endif
 \set ECHO none
   name  
 --------

--- a/expected/nlssort_1.out
+++ b/expected/nlssort_1.out
@@ -1,0 +1,8 @@
+-- Tests for nlssort
+-- Skip this test unless it's a Linux/glibc system with the "en_US.utf8" locale installed.
+SELECT getdatabaseencoding() <> 'UTF8' OR
+       NOT EXISTS (SELECT 1 FROM pg_collation WHERE collname = 'en_US' AND collencoding = pg_char_to_encoding('UTF8')) OR
+       version() !~ 'linux-gnu'
+       AS skip_test \gset
+\if :skip_test
+\quit

--- a/sql/nlssort.sql
+++ b/sql/nlssort.sql
@@ -1,4 +1,14 @@
 -- Tests for nlssort
+
+-- Skip this test unless it's a Linux/glibc system with the "en_US.utf8" locale installed.
+SELECT getdatabaseencoding() <> 'UTF8' OR
+       NOT EXISTS (SELECT 1 FROM pg_collation WHERE collname = 'en_US' AND collencoding = pg_char_to_encoding('UTF8')) OR
+       version() !~ 'linux-gnu'
+       AS skip_test \gset
+\if :skip_test
+\quit
+\endif
+
 \set ECHO none
 SET client_min_messages = error;
 DROP DATABASE IF EXISTS regression_sort;


### PR DESCRIPTION
This test fails on other systems because either the en_US.utf8 locale isn't
available or gives a different ordering.

This fixes #185.