### PR TITLE
nlssort: Add a missing call to PG_RE_THROW.

### DIFF
--- a/others.c
+++ b/others.c
@@ -241,6 +241,8 @@ _nls_run_strxfrm(text *string, text *locale)
 			if (!setlocale(LC_COLLATE, lc_collate_cache))
 				elog(FATAL, "failed to set back the default LC_COLLATE value [%s]", lc_collate_cache);
 		}
+
+		PG_RE_THROW();
 	}
 	PG_END_TRY ();
 


### PR DESCRIPTION
Before:
```
postgres=# select length(oracle.nlssort(repeat(repeat('x', 1000), 200000), 'en_US.UTF-8'));
server closed the connection unexpectedly
	This probably means the server terminated abnormally
	before or while processing the request.

LOG:  server process (PID 76533) was terminated by signal 11: Segmentation fault: 11
```

After:
```
postgres=# select length(oracle.nlssort(repeat(repeat('x', 1000), 200000), 'en_US.UTF-8'));
ERROR:  invalid memory alloc request size 1600000009
```