### PR TITLE
Check for negative prefix in is_prefix()

### DIFF
--- a/plvstr.c
+++ b/plvstr.c
@@ -523,6 +523,11 @@ plvstr_is_prefix_int (PG_FUNCTION_ARGS)
 			result = true;
 			break;
 		}
+		if (prefix < 0)
+		{
+			result = false;
+			break;
+		}
 		n = n / 10;
 
 	} while (n >= prefix);
@@ -542,6 +547,11 @@ plvstr_is_prefix_int64 (PG_FUNCTION_ARGS)
 		if (n == prefix)
 		{
 			result = true;
+			break;
+		}
+		if (prefix < 0)
+		{
+			result = false;
 			break;
 		}
 		n = n / 10;


### PR DESCRIPTION
Respond with `false`, if the caller provided a negative prefix. 

The previous behavior is that given a negative prefix this function (both `int4`/`int8`) would go into a tight loop, not adhering to timeouts / `Ctrl-C` aborts etc.

- The patch retains the current behavior (to return `True`) if prefix is `0`.
- The text version works fine (with negative prefix) already.
- Repro is on `3.15`, but fails on versions as old as `3.6` too.


```
postgres14@postgres=> \dx orafce
                                               List of installed extensions
  Name  | Version | Schema |                                          Description
--------+---------+--------+-----------------------------------------------------------------------------------------------
 orafce | 3.15    | public | Functions and operators that emulate a subset of functions and packages from the Oracle RDBMS
(1 row)

postgres14@postgres=> select plvstr.is_prefix(113, 1);
 is_prefix
-----------
 t
(1 row)

postgres14@postgres=> select plvstr.is_prefix(113, 0);
 is_prefix
-----------
 t
(1 row)

postgres14@postgres=> select plvstr.is_prefix(113, -1);
^CCancel request sent
^Z

```