### PR TITLE
Fix database creation during installchecks for ICU cluster

### DIFF
--- a/sql/nlssort.sql
+++ b/sql/nlssort.sql
@@ -12,7 +12,21 @@ SELECT getdatabaseencoding() <> 'UTF8' OR
 \set ECHO none
 SET client_min_messages = error;
 DROP DATABASE IF EXISTS regression_sort;
+
+-- For PG >= 15 explicitly set the locale provider libc when creating the
+-- database with SQL_ASCII encoding. Otherwise during installcheck the new
+-- database may use the ICU locale provider (from template0) which does not
+-- support this encoding.
+
+SELECT current_setting('server_version_num')::integer >= 150000
+       AS set_libc_locale_provider \gset
+
+\if :set_libc_locale_provider
+CREATE DATABASE regression_sort WITH TEMPLATE = template0 ENCODING='SQL_ASCII' LC_COLLATE='C' LC_CTYPE='C' LOCALE_PROVIDER='libc';
+\else
 CREATE DATABASE regression_sort WITH TEMPLATE = template0 ENCODING='SQL_ASCII' LC_COLLATE='C' LC_CTYPE='C';
+\endif
+
 \c regression_sort
 SET client_min_messages = error;
 


### PR DESCRIPTION
For PG >= 15 explicitly set the locale provider libc when creating the database with SQL_ASCII encoding. Otherwise during installcheck the new database may use the ICU locale provider (from template0) which does not support this encoding.

Steps to reproduce:

1. Build orafce with PG >= 15.
2. Create a cluster for installcheck:
`initdb --locale-provider icu --icu-locale en-US -D data && pg_ctl -D data -l logfile start`
3. Run installcheck.
4. See regression.diffs:
```
diff -U3 /home/marina/orafce/expected/nlssort_1.out /home/marina/orafce/results/nlssort.out
--- /home/marina/orafce/expected/nlssort_1.out	2022-10-31 09:10:59.057911822 +0300
+++ /home/marina/orafce/results/nlssort.out	2022-10-31 09:41:31.636318864 +0300
@@ -6,3 +6,7 @@
        AS skip_test \gset
 \if :skip_test
 \quit
+\endif
+\set ECHO none
+ERROR:  encoding "SQL_ASCII" is not supported with ICU provider
+\connect: connection to server on socket "/tmp/.s.PGSQL.5432" failed: FATAL:  database "regression_sort" does not exist
```