### PR TITLE
fix: CONNECT_BY_ROOT in hierarchical query is converted to WITH RECURSIVE syntax

### DIFF
--- a/doc/sql_migration/sql_migration04.md
+++ b/doc/sql_migration/sql_migration04.md
@@ -805,7 +805,7 @@ In a recursive query that uses a WITH clause, add a root column that also uses t
 2. Add root column to the column list of the query result of the WITH clause.
 
 -	In the first query, specify the root columnName to the values of the columns from the root to the node.
--	Specify m.columnName in the next query. (columnName is a root column.)
+-	Specify m.rootName in the next query. (rootName is a root column.)
 
 
 The following shows the conversion format containing rootName.
@@ -817,7 +817,7 @@ WITH RECURSIVE queryName(
 ( SELECT columnUsed, columnName
       FROM  targetTableOfHierarchicalQuery
     UNION ALL
-    SELECT columnUsed(qualified by n), w.columnName
+    SELECT columnUsed(qualified by n), w.rootName
       FROM  targetTableOfHierarchicalQuery  n,
             queryName  w
       WHERE conditionalExprOfConnectByClause )
@@ -838,7 +838,7 @@ The example below shows migration when the root data is displayed.
 <tbody>
 <tr>
 <td align="left">
-<pre><code>SELECT staff_id, name, <b>CONNECT_BY_ROOT name as "Manager" </b>
+<pre><code>SELECT staff_id, name, <b>CONNECT_BY_ROOT name as "ROOT" </b>
   FROM staff_table 
   START WITH staff_id = '1001' 
   CONNECT BY PRIOR staff_id = manager_id;
@@ -855,14 +855,15 @@ The example below shows migration when the root data is displayed.
 <td align="left">
 <pre><code>WITH RECURSIVE staff_table_w( staff_id, 
  name, 
- Manager ) AS 
- ( SELECT staff_id, name, <b>name </b>
+ ROOT ) AS 
+ (   SELECT staff_id, name, <b>name </b>
        FROM staff_table 
      UNION ALL 
-     SELECT n.staff_id, n.name, <b>w.name </b>
+     SELECT n.staff_id, n.name, <b>w.ROOT </b>
        FROM staff_table n, staff_table_w w 
-       WHERE w.staff_id = n.manager_id ) 
- SELECT staff_id, name, Manager 
+       WHERE w.staff_id = n.manager_id
+ )
+ SELECT staff_id, name, ROOT 
  FROM staff_table_w;</code></pre>
 </td>
 </tr>

--- a/doc/sql_migration/sql_migration04.md
+++ b/doc/sql_migration/sql_migration04.md
@@ -838,7 +838,7 @@ The example below shows migration when the root data is displayed.
 <tbody>
 <tr>
 <td align="left">
-<pre><code>SELECT staff_id, name, <b>CONNECT_BY_ROOT name as "ROOT" </b>
+<pre><code>SELECT staff_id, name, <b>CONNECT_BY_ROOT name as "Manager" </b>
   FROM staff_table 
   START WITH staff_id = '1001' 
   CONNECT BY PRIOR staff_id = manager_id;
@@ -855,15 +855,15 @@ The example below shows migration when the root data is displayed.
 <td align="left">
 <pre><code>WITH RECURSIVE staff_table_w( staff_id, 
  name, 
- ROOT ) AS 
+ Manager ) AS 
  (   SELECT staff_id, name, <b>name </b>
        FROM staff_table 
      UNION ALL 
-     SELECT n.staff_id, n.name, <b>w.ROOT </b>
+     SELECT n.staff_id, n.name, <b>w.Manager </b>
        FROM staff_table n, staff_table_w w 
        WHERE w.staff_id = n.manager_id
  )
- SELECT staff_id, name, ROOT 
+ SELECT staff_id, name, Manager 
  FROM staff_table_w;</code></pre>
 </td>
 </tr>


### PR DESCRIPTION
CONNECT_BY_ROOT should be the root node of hierarchical query,  not the upper node of the current node.