### PR TITLE
Fix REGEXP_COUNT and REGEXP_SUBSTR functions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ OBJS= regexp.o\
 
 EXTENSION = orafce
 
-DATA = orafce--4.8.sql\
+DATA = orafce--4.9.sql\
 		orafce--3.2--3.3.sql\
 		orafce--3.3--3.4.sql\
 		orafce--3.4--3.5.sql\
@@ -62,7 +62,8 @@ DATA = orafce--4.8.sql\
 		orafce--4.4--4.5.sql\
 		orafce--4.5--4.6.sql\
 		orafce--4.6--4.7.sql\
-		orafce--4.7--4.8.sql
+		orafce--4.7--4.8.sql\
+		orafce--4.8--4.9.sql
 
 
 DOCS = README.asciidoc COPYRIGHT.orafce INSTALL.orafce

--- a/expected/regexp_func.out
+++ b/expected/regexp_func.out
@@ -1,6 +1,6 @@
 -- Test for the regexp_*() function
 \set ECHO none
-SET search_path TO oracle,"$user", public, pg_catalog;
+SET search_path TO oracle, "$user", public, pg_catalog;
 ----
 -- Tests for REGEXP_LIKE()
 ----
@@ -112,6 +112,20 @@ SELECT REGEXP_LIKE('ORANGE' || chr(10) || 'GREEN', '^..([aeiou])\1', 'im');
 ----
 -- Tests for REGEXP_COUNT()
 ----
+-- ORACLE> SELECT REGEXP_COUNT('a,b' || chr(10) || 'c','[^,]+') FROM DUAL; -> 2
+SELECT REGEXP_COUNT('a,b' || chr(10) || 'c','[^,]+');
+ regexp_count 
+--------------
+            2
+(1 row)
+
+-- ORACLE> SELECT REGEXP_COUNT('a,b' || chr(10) || 'c','b.c') FROM DUAL; -> 0
+SELECT REGEXP_COUNT('a,b' || chr(10) || 'c','b.c');
+ regexp_count 
+--------------
+            0
+(1 row)
+
 -- ORACLE> SELECT REGEXP_COUNT('a'||CHR(10)||'d', 'a.d') FROM DUAL; -> 0
 SELECT REGEXP_COUNT('a'||CHR(10)||'d', 'a.d');
  regexp_count 
@@ -465,6 +479,21 @@ SELECT REGEXP_INSTR('123 123456 1234567, 1234567 1234567 12', '[^ ]+', 1, 6, 1, 
 ----
 -- Tests for REGEXP_SUBSTR()
 ----
+-- ORACLE> SELECT REGEXP_SUBSTR('a,b'||chr(10)||'c','[^,]+',1,2) FROM DUAL; -> b and c
+SELECT REGEXP_SUBSTR('a,b'||chr(10)||'c','[^,]+',1,2);
+ regexp_substr 
+---------------
+ b            +
+ c
+(1 row)
+
+-- ORACLE> SELECT REGEXP_SUBSTR('a,b'||chr(10)||'c','.',1,4) FROM DUAL; -> c
+SELECT REGEXP_SUBSTR('a,b'||chr(10)||'c','.',1,4);
+ regexp_substr 
+---------------
+ c
+(1 row)
+
 -- ORACLE> SELECT REGEXP_SUBSTR('number of your street, zipcode town, FR', ',[^,]+') FROM DUAL; -> , zipcode town
 SELECT REGEXP_SUBSTR('number of your street, zipcode town, FR', ',[^,]+');
  regexp_substr  

--- a/orafce--4.8--4.9.sql
+++ b/orafce--4.8--4.9.sql
@@ -1,0 +1,177 @@
+-- regexp_count_pattern_fix: replace any occurence of a dot into a [^\n] pattern.
+CREATE OR REPLACE FUNCTION oracle.regexp_count_pattern_fix(text)
+RETURNS text
+AS $$
+DECLARE
+  v_pattern text;
+BEGIN
+  -- Replace any occurences of a dot by [^\n]
+  -- to have the same behavior as Oracle
+  v_pattern := regexp_replace($1, '\\\.', '#ESCDOT#', 'g');
+  v_pattern := regexp_replace(v_pattern, '\.', '[^\n]', 'g');
+  v_pattern := regexp_replace(v_pattern, '#ESCDOT#', '\.', 'g');
+
+  RETURN v_pattern;
+END;
+$$
+LANGUAGE plpgsql IMMUTABLE STRICT PARALLEL SAFE;
+
+-- REGEXP_COUNT( string text, pattern text ) -> integer
+CREATE OR REPLACE FUNCTION oracle.regexp_count(text, text)
+RETURNS integer
+AS $$
+  -- Oracle default behavior is newline-sensitive,
+  -- PostgreSQL not, so force 'p' modifier to affect
+  -- newline-sensitivity but not ^ and $ search.
+  SELECT count(*)::integer FROM regexp_matches($1, oracle.regexp_count_pattern_fix($2), 'sg');
+$$
+LANGUAGE 'sql' STRICT IMMUTABLE PARALLEL SAFE;
+
+-- REGEXP_COUNT( string text, pattern text, position int ) -> integer
+CREATE OR REPLACE FUNCTION oracle.regexp_count(text, text, integer)
+RETURNS integer
+AS $$
+DECLARE
+  v_cnt integer;
+  v_pattern text;
+BEGIN
+  -- Check numeric arguments
+  IF $3 < 1 THEN
+    RAISE EXCEPTION 'argument ''position'' must be a number greater than 0';
+  END IF;
+
+  v_pattern := '(' || oracle.regexp_count_pattern_fix($2) || ')';
+
+  -- Oracle default behavior is newline-sensitive,
+  -- PostgreSQL not, so force 's' modifier to affect
+  -- newline-sensitivity but not ^ and $ search.
+  v_cnt :=  (SELECT count(*)::integer FROM regexp_matches(substr($1, $3), v_pattern, 'sg'));
+  RETURN v_cnt;
+END;
+$$
+LANGUAGE plpgsql STRICT IMMUTABLE PARALLEL SAFE;
+
+-- REGEXP_COUNT( string text, pattern text, position int ) -> integer
+CREATE OR REPLACE FUNCTION oracle.regexp_count(text, text, integer)
+RETURNS integer
+AS $$
+DECLARE
+  v_cnt integer;
+BEGIN
+  -- Check numeric arguments
+  IF $3 < 1 THEN
+    RAISE EXCEPTION 'argument ''position'' must be a number greater than 0';
+  END IF;
+
+  -- Oracle default behavior is newline-sensitive,
+  -- PostgreSQL not, so force 'p' modifier to affect
+  -- newline-sensitivity but not ^ and $ search.
+  v_cnt :=  (SELECT count(*)::integer FROM regexp_matches(substr($1, $3), oracle.regexp_count_pattern_fix($2), 'sg'));
+  RETURN v_cnt;
+END;
+$$
+LANGUAGE plpgsql STRICT IMMUTABLE PARALLEL SAFE;
+
+-- REGEXP_COUNT( string text, pattern text, position int, flags text ) -> integer
+CREATE OR REPLACE FUNCTION oracle.regexp_count(text, text, integer, text)
+RETURNS integer
+AS $$
+DECLARE
+  modifiers text;
+  v_cnt   integer;
+BEGIN
+  -- Only modifier can be NULL
+  IF $1 IS NULL OR $2 IS NULL OR $3 IS NULL THEN
+    RETURN NULL;
+  END IF;
+  -- Check numeric arguments
+  IF $3 < 1 THEN
+    RAISE EXCEPTION 'argument ''position'' must be a number greater than 0';
+  END IF;
+
+  modifiers := oracle.translate_oracle_modifiers($4, true);
+  v_cnt := (SELECT count(*)::integer FROM regexp_matches(substr($1, $3), $2, modifiers));
+  RETURN v_cnt;
+END;
+$$
+LANGUAGE plpgsql IMMUTABLE PARALLEL SAFE;
+
+-- REGEXP_SUBSTR( string text, pattern text ) -> text
+CREATE OR REPLACE FUNCTION oracle.regexp_substr(text, text)
+RETURNS text
+AS $$
+DECLARE
+  v_substr text;
+  v_pattern text;
+BEGIN
+  -- Without subexpression specified, assume 0 which mean that the first
+  -- position for the substring matching the whole pattern is returned.
+  -- We need to enclose the pattern between parentheses.
+  v_pattern := '(' || $2 || ')';
+
+  -- Oracle default behavior is newline-sensitive,
+  -- PostgreSQL not, so force 'p' modifier to affect
+  -- newline-sensitivity but not ^ and $ search.
+  v_substr := (SELECT (regexp_matches($1, v_pattern, 'sg'))[1] OFFSET 0 LIMIT 1);
+  RETURN v_substr;
+END;
+$$
+LANGUAGE plpgsql STRICT IMMUTABLE PARALLEL SAFE;
+
+-- REGEXP_SUBSTR( string text, pattern text, position int ) -> text
+CREATE OR REPLACE FUNCTION oracle.regexp_substr(text, text, int)
+RETURNS text
+AS $$
+DECLARE
+  v_substr text;
+  v_pattern text;
+BEGIN
+  -- Check numeric arguments
+  IF $3 < 1 THEN
+    RAISE EXCEPTION 'argument ''position'' must be a number greater than 0';
+  END IF;
+
+  -- Without subexpression specified, assume 0 which mean that the first
+  -- position for the substring matching the whole pattern is returned.
+  -- We need to enclose the pattern between parentheses.
+  v_pattern := '(' || $2 || ')';
+
+  -- Oracle default behavior is newline-sensitive,
+  -- PostgreSQL not, so force 'p' modifier to affect
+  -- newline-sensitivity but not ^ and $ search.
+  v_substr := (SELECT (regexp_matches(substr($1, $3), v_pattern, 'sg'))[1] OFFSET 0 LIMIT 1);
+  RETURN v_substr;
+END;
+$$
+LANGUAGE plpgsql STRICT IMMUTABLE PARALLEL SAFE;
+
+-- REGEXP_SUBSTR( string text, pattern text, position int, occurence int ) -> text
+CREATE OR REPLACE FUNCTION oracle.regexp_substr(text, text, integer, integer)
+RETURNS text
+AS $$
+DECLARE
+  v_substr text;
+  v_pattern text;
+BEGIN
+  -- Check numeric arguments
+  IF $3 < 1 THEN
+    RAISE EXCEPTION 'argument ''position'' must be a number greater than 0';
+  END IF;
+  IF $4 < 1 THEN
+    RAISE EXCEPTION 'argument ''occurence'' must be a number greater than 0';
+  END IF;
+
+  -- Without subexpression specified, assume 0 which mean that the first
+  -- position for the substring matching the whole pattern is returned.
+  -- We need to enclose the pattern between parentheses.
+  v_pattern := '(' || $2 || ')';
+
+  -- Oracle default behavior is newline-sensitive,
+  -- PostgreSQL not, so force 'p' modifier to affect
+  -- newline-sensitivity but not ^ and $ search.
+  v_substr := (SELECT (regexp_matches(substr($1, $3), v_pattern, 'sg'))[1] OFFSET $4 - 1 LIMIT 1);
+  RETURN v_substr;
+END;
+$$
+LANGUAGE plpgsql STRICT IMMUTABLE PARALLEL SAFE;
+

--- a/orafce--4.9.sql
+++ b/orafce--4.9.sql
@@ -3674,6 +3674,24 @@ END;
 $$
 LANGUAGE plpgsql IMMUTABLE PARALLEL SAFE;
 
+-- regexp_count_pattern_fix: replace any occurence of a dot into a [^\n] pattern.
+CREATE OR REPLACE FUNCTION oracle.regexp_count_pattern_fix(text)
+RETURNS text
+AS $$
+DECLARE
+  v_pattern text;
+BEGIN
+  -- Replace any occurences of a dot by [^\n]
+  -- to have the same behavior as Oracle
+  v_pattern := regexp_replace($1, '\\\.', '#ESCDOT#', 'g');
+  v_pattern := regexp_replace(v_pattern, '\.', '[^\n]', 'g');
+  v_pattern := regexp_replace(v_pattern, '#ESCDOT#', '\.', 'g');
+
+  RETURN v_pattern;
+END;
+$$
+LANGUAGE plpgsql IMMUTABLE STRICT PARALLEL SAFE;
+
 -- REGEXP_COUNT( string text, pattern text ) -> integer
 CREATE OR REPLACE FUNCTION oracle.regexp_count(text, text)
 RETURNS integer
@@ -3681,9 +3699,33 @@ AS $$
   -- Oracle default behavior is newline-sensitive,
   -- PostgreSQL not, so force 'p' modifier to affect
   -- newline-sensitivity but not ^ and $ search.
-  SELECT count(*)::integer FROM regexp_matches($1, $2, 'pg');
+  SELECT count(*)::integer FROM regexp_matches($1, oracle.regexp_count_pattern_fix($2), 'sg');
 $$
 LANGUAGE 'sql' STRICT IMMUTABLE PARALLEL SAFE;
+
+-- REGEXP_COUNT( string text, pattern text, position int ) -> integer
+CREATE OR REPLACE FUNCTION oracle.regexp_count(text, text, integer)
+RETURNS integer
+AS $$
+DECLARE
+  v_cnt integer;
+  v_pattern text;
+BEGIN
+  -- Check numeric arguments
+  IF $3 < 1 THEN
+    RAISE EXCEPTION 'argument ''position'' must be a number greater than 0';
+  END IF;
+
+  v_pattern := '(' || oracle.regexp_count_pattern_fix($2) || ')';
+
+  -- Oracle default behavior is newline-sensitive,
+  -- PostgreSQL not, so force 's' modifier to affect
+  -- newline-sensitivity but not ^ and $ search.
+  v_cnt :=  (SELECT count(*)::integer FROM regexp_matches(substr($1, $3), v_pattern, 'sg'));
+  RETURN v_cnt;
+END;
+$$
+LANGUAGE plpgsql STRICT IMMUTABLE PARALLEL SAFE;
 
 -- REGEXP_COUNT( string text, pattern text, position int ) -> integer
 CREATE OR REPLACE FUNCTION oracle.regexp_count(text, text, integer)
@@ -3700,7 +3742,7 @@ BEGIN
   -- Oracle default behavior is newline-sensitive,
   -- PostgreSQL not, so force 'p' modifier to affect
   -- newline-sensitivity but not ^ and $ search.
-  v_cnt :=  (SELECT count(*)::integer FROM regexp_matches(substr($1, $3), $2, 'pg'));
+  v_cnt :=  (SELECT count(*)::integer FROM regexp_matches(substr($1, $3), oracle.regexp_count_pattern_fix($2), 'sg'));
   RETURN v_cnt;
 END;
 $$
@@ -3777,12 +3819,12 @@ BEGIN
   -- Without subexpression specified, assume 0 which mean that the first
   -- position for the substring matching the whole pattern is returned.
   -- We need to enclose the pattern between parentheses.
-  v_pattern := '(' || $2 || ')';
+  v_pattern := '(' || oracle.regexp_count_pattern_fix($2) || ')';
 
   -- Oracle default behavior is newline-sensitive,
   -- PostgreSQL not, so force 'p' modifier to affect
   -- newline-sensitivity but not ^ and $ search.
-  v_substr := (SELECT (regexp_matches($1, v_pattern, 'pg'))[1] OFFSET 0 LIMIT 1);
+  v_substr := (SELECT (regexp_matches($1, v_pattern, 'sg'))[1] OFFSET 0 LIMIT 1);
   RETURN v_substr;
 END;
 $$
@@ -3804,12 +3846,12 @@ BEGIN
   -- Without subexpression specified, assume 0 which mean that the first
   -- position for the substring matching the whole pattern is returned.
   -- We need to enclose the pattern between parentheses.
-  v_pattern := '(' || $2 || ')';
+  v_pattern := '(' || oracle.regexp_count_pattern_fix($2) || ')';
 
   -- Oracle default behavior is newline-sensitive,
   -- PostgreSQL not, so force 'p' modifier to affect
   -- newline-sensitivity but not ^ and $ search.
-  v_substr := (SELECT (regexp_matches(substr($1, $3), v_pattern, 'pg'))[1] OFFSET 0 LIMIT 1);
+  v_substr := (SELECT (regexp_matches(substr($1, $3), v_pattern, 'sg'))[1] OFFSET 0 LIMIT 1);
   RETURN v_substr;
 END;
 $$
@@ -3834,12 +3876,12 @@ BEGIN
   -- Without subexpression specified, assume 0 which mean that the first
   -- position for the substring matching the whole pattern is returned.
   -- We need to enclose the pattern between parentheses.
-  v_pattern := '(' || $2 || ')';
+  v_pattern := '(' || oracle.regexp_count_pattern_fix($2) || ')';
 
   -- Oracle default behavior is newline-sensitive,
   -- PostgreSQL not, so force 'p' modifier to affect
   -- newline-sensitivity but not ^ and $ search.
-  v_substr := (SELECT (regexp_matches(substr($1, $3), v_pattern, 'pg'))[1] OFFSET $4 - 1 LIMIT 1);
+  v_substr := (SELECT (regexp_matches(substr($1, $3), v_pattern, 'sg'))[1] OFFSET $4 - 1 LIMIT 1);
   RETURN v_substr;
 END;
 $$

--- a/orafce.control
+++ b/orafce.control
@@ -1,5 +1,5 @@
 # orafce extension
 comment = 'Functions and operators that emulate a subset of functions and packages from the Oracle RDBMS'
-default_version = '4.8'
+default_version = '4.9'
 module_pathname = '$libdir/orafce'
 relocatable = false

--- a/sql/regexp_func.sql
+++ b/sql/regexp_func.sql
@@ -5,7 +5,7 @@ SET client_encoding = utf8;
 \set VERBOSITY terse
 \set ECHO all
 
-SET search_path TO oracle,"$user", public, pg_catalog;
+SET search_path TO oracle, "$user", public, pg_catalog;
 
 ----
 -- Tests for REGEXP_LIKE()
@@ -46,6 +46,10 @@ SELECT REGEXP_LIKE('ORANGE' || chr(10) || 'GREEN', '^..([aeiou])\1', 'im');
 -- Tests for REGEXP_COUNT()
 ----
 
+-- ORACLE> SELECT REGEXP_COUNT('a,b' || chr(10) || 'c','[^,]+') FROM DUAL; -> 2
+SELECT REGEXP_COUNT('a,b' || chr(10) || 'c','[^,]+');
+-- ORACLE> SELECT REGEXP_COUNT('a,b' || chr(10) || 'c','b.c') FROM DUAL; -> 0
+SELECT REGEXP_COUNT('a,b' || chr(10) || 'c','b.c');
 -- ORACLE> SELECT REGEXP_COUNT('a'||CHR(10)||'d', 'a.d') FROM DUAL; -> 0
 SELECT REGEXP_COUNT('a'||CHR(10)||'d', 'a.d');
 -- ORACLE> SELECT REGEXP_COUNT('a'||CHR(10)||'d', 'a.d', 1, 'm') FROM DUAL; -> 0
@@ -175,6 +179,10 @@ SELECT REGEXP_INSTR('123 123456 1234567, 1234567 1234567 12', '[^ ]+', 1, 6, 1, 
 -- Tests for REGEXP_SUBSTR()
 ----
 
+-- ORACLE> SELECT REGEXP_SUBSTR('a,b'||chr(10)||'c','[^,]+',1,2) FROM DUAL; -> b and c
+SELECT REGEXP_SUBSTR('a,b'||chr(10)||'c','[^,]+',1,2);
+-- ORACLE> SELECT REGEXP_SUBSTR('a,b'||chr(10)||'c','.',1,4) FROM DUAL; -> c
+SELECT REGEXP_SUBSTR('a,b'||chr(10)||'c','.',1,4);
 -- ORACLE> SELECT REGEXP_SUBSTR('number of your street, zipcode town, FR', ',[^,]+') FROM DUAL; -> , zipcode town
 SELECT REGEXP_SUBSTR('number of your street, zipcode town, FR', ',[^,]+');
 -- ORACLE> SELECT REGEXP_SUBSTR('http://www.example.com/products', 'http://([[:alnum:]]+\.?){3,4}/?') FROM DUAL; -> http://www.example.com/


### PR DESCRIPTION
to have the same behavior than Oracle with newline characters and the use of dot in the pattern.