### PR TITLE
change timezone to postgres server timezone instead of orafce.timezone

### DIFF
--- a/datefce.c
+++ b/datefce.c
@@ -1009,8 +1009,6 @@ ora_timestamp_round(PG_FUNCTION_ARGS)
  * Purpose:
  *
  * Returns statement_timestamp in server time zone 
- *   Note - server time zone doesn't exists on PostgreSQL - emulated
- *   by orafce_timezone
  *
  ********************************************************************/
 
@@ -1019,10 +1017,12 @@ orafce_sysdate(PG_FUNCTION_ARGS)
 {
 	Datum sysdate;
 	Datum sysdate_scaled;
+	const char* varname;
+	char* value;
 
-
+	value = GetConfigOptionByName("timezone", &varname, false);
 	sysdate = DirectFunctionCall2(timestamptz_zone,
-					CStringGetTextDatum(orafce_timezone),
+					CStringGetTextDatum(value),
 					TimestampTzGetDatum(GetCurrentStatementStartTimestamp()));
 
 	/* necessary to cast to timestamp(0) to emulate Oracle's date */


### PR DESCRIPTION
`orafce_sysdate` function uses its own timezone value from `orafce.timezone` GUC parameter. The default value for `orafce.timezone` is `GMT`. That makes some troubles when someone is not in GMT timezone. Here's trouble in detail:

```text
ldd=# show timezone;
   TimeZone
---------------
 Asia/Shanghai
(1 row)

ldd=# select oracle.sysdate();
       sysdate
---------------------
 2024-03-07 09:20:09
(1 row)

ldd=# select now();
              now
-------------------------------
 2024-03-07 17:20:13.596163+08
(1 row)

ldd=# set orafce.timezone = 'Asia/Shanghai';
SET
ldd=# select oracle.sysdate();
       sysdate
---------------------
 2024-03-07 17:20:47
(1 row)

ldd=# set timezone = 'UTC';
SET
ldd=# select now();
              now
-------------------------------
 2024-03-07 09:21:16.804505+00
(1 row)
ldd=# select oracle.sysdate();
       sysdate
---------------------
 2024-03-07 17:21:40
(1 row)
ldd=# set orafce.timezone = 'utc';
SET
ldd=# select oracle.sysdate();
       sysdate
---------------------
 2024-03-07 09:23:11
(1 row)
```

It's a little trouble to maintain consistency with `now` and `sysdate`.

In my pull request, I get the postgresql server `timezone` setting by function `GetConfigOptionByName`.