### PR TITLE
Raise an error when Oracle's to_date() bugs are reached.

### DIFF
--- a/expected/orafce.out
+++ b/expected/orafce.out
@@ -2620,10 +2620,27 @@ SELECT to_date('112012', 'J');
  4407-07-30 BC
 (1 row)
 
+SELECT to_date('1003/03/15', 'yyyy/mm/dd');
+  to_date   
+------------
+ 1003-03-15
+(1 row)
+
 SELECT oracle.to_date('112012', 'J');
+ERROR:  with dates before 1582-10-05 ('J2299159') Oracle doesn't return the same date than PostgreSQL.
+SELECT oracle.to_date('1003-03-15', 'yyyy-mm-dd');
+ERROR:  Dates before 1100-03-01 cannot be verified due to a bug in Oracle.
+SET orafce.oracle_compatibility_date_limit TO off;
+SELECT oracle.to_date('112012', 'J');
+        to_date         
+------------------------
+ 4407-07-30 00:00:00 BC
+(1 row)
+
+SELECT oracle.to_date('1003/03/15', 'yyyy/mm/dd');
        to_date       
 ---------------------
- 4406-09-03 00:00:00
+ 1003-03-15 00:00:00
 (1 row)
 
 SELECT bitand(5,1), bitand(5,2), bitand(5,4);

--- a/expected/orafce.out
+++ b/expected/orafce.out
@@ -2627,7 +2627,7 @@ SELECT to_date('1003/03/15', 'yyyy/mm/dd');
 (1 row)
 
 SELECT oracle.to_date('112012', 'J');
-ERROR:  with dates before 1582-10-05 ('J2299159') Oracle doesn't return the same date than PostgreSQL.
+ERROR:  Dates before 1582-10-05 ('J2299159') cannot be verified due to a bug in Oracle.
 SELECT oracle.to_date('1003-03-15', 'yyyy-mm-dd');
 ERROR:  Dates before 1100-03-01 cannot be verified due to a bug in Oracle.
 SET orafce.oracle_compatibility_date_limit TO off;

--- a/orafce--4.12--4.13.sql
+++ b/orafce--4.12--4.13.sql
@@ -9,3 +9,14 @@ BEGIN
   END IF;
 END;
 $$;
+
+CREATE FUNCTION oracle.orafce__obsolete_to_date(str text, fmt text)
+RETURNS timestamp
+AS 'MODULE_PATHNAME','ora_to_date'
+LANGUAGE C STABLE STRICT PARALLEL SAFE;
+
+CREATE FUNCTION oracle.to_date(TEXT, TEXT)
+RETURNS oracle.date
+AS $$ SELECT oracle.orafce__obsolete_to_date($1, $2)::oracle.date; $$
+LANGUAGE SQL STABLE STRICT PARALLEL SAFE;
+

--- a/orafce--4.13.sql
+++ b/orafce--4.13.sql
@@ -176,6 +176,11 @@ RETURNS timestamp
 AS 'MODULE_PATHNAME','ora_to_date'
 LANGUAGE C STABLE STRICT PARALLEL SAFE;
 
+CREATE FUNCTION oracle.orafce__obsolete_to_date(str text, fmt text)
+RETURNS timestamp
+AS 'MODULE_PATHNAME','ora_to_date'
+LANGUAGE C STABLE STRICT PARALLEL SAFE;
+
 CREATE FUNCTION oracle.to_multi_byte(str text)
 RETURNS text
 AS 'MODULE_PATHNAME','orafce_to_multi_byte'
@@ -486,14 +491,10 @@ RETURNS oracle.date
 AS $$ SELECT oracle.orafce__obsolete_to_date($1)::oracle.date; $$
 LANGUAGE SQL STABLE STRICT PARALLEL SAFE;
 
-CREATE OR REPLACE FUNCTION oracle.to_date (TEXT, TEXT) RETURNS oracle.date AS $$
-SELECT CASE WHEN upper($2) = 'J' THEN
-    substr((pg_catalog.to_date($1, $2) + '400 days'::interval)::text, 1, 19)::oracle.date
-  ELSE
-    TO_TIMESTAMP($1,$2)::oracle.date
-  END;
-$$ LANGUAGE SQL
-STRICT IMMUTABLE PARALLEL SAFE;
+CREATE FUNCTION oracle.to_date(TEXT, TEXT)
+RETURNS oracle.date
+AS $$ SELECT oracle.orafce__obsolete_to_date($1, $2)::oracle.date; $$
+LANGUAGE SQL STABLE STRICT PARALLEL SAFE;
 
 CREATE FUNCTION oracle.to_char(timestamp)
 RETURNS TEXT

--- a/orafce.c
+++ b/orafce.c
@@ -172,6 +172,15 @@ _PG_init(void)
 									orafce_umask_check_hook,
 									orafce_umask_assign_hook, NULL);
 
+	DefineCustomBoolVariable("orafce.oracle_compatibility_date_limit",
+									"Specify if an error is raised when the Oracle to_date() bug is reached.",
+									NULL,
+									&orafce_emit_error_on_date_bug,
+									true,
+									PGC_USERSET,
+									0,
+									NULL, NULL, NULL);
+
 	EmitWarningsOnPlaceholders("orafce");
 
 	RegisterXactCallback(orafce_xact_cb, NULL);

--- a/orafce.h
+++ b/orafce.h
@@ -46,6 +46,7 @@ extern char *orafce_umask_str;
 extern bool orafce_initialized;
 extern bool orafce_varchar2_null_safe_concat;
 extern int orafce_substring_length_is_zero;
+extern bool orafce_emit_error_on_date_bug;
 
 extern char *orafce_sys_guid_source;
 

--- a/sql/orafce.sql
+++ b/sql/orafce.sql
@@ -543,7 +543,12 @@ SELECT to_number(1210.73::numeric, 9999.99::numeric);
 
 SELECT to_date('2009-01-02');
 SELECT to_date('112012', 'J');
+SELECT to_date('1003/03/15', 'yyyy/mm/dd');
 SELECT oracle.to_date('112012', 'J');
+SELECT oracle.to_date('1003-03-15', 'yyyy-mm-dd');
+SET orafce.oracle_compatibility_date_limit TO off;
+SELECT oracle.to_date('112012', 'J');
+SELECT oracle.to_date('1003/03/15', 'yyyy/mm/dd');
 
 SELECT bitand(5,1), bitand(5,2), bitand(5,4);
 SELECT sinh(1.570796)::numeric(10, 8), cosh(1.570796)::numeric(10, 8), tanh(4)::numeric(10, 8);


### PR DESCRIPTION
This patch raise an error when Oracle's to_date() bugs are reached. This concern dates before 1582-10-05 ('J2299159') using the 'J' format and dates before 1100-03-01 that cannot be verified due to a bug in Oracle with other format.
    
Add orafce.oracle_compatibility_date_limit configuration variable to be able to disable this feature. Enabled by defaut.
