### PR TITLE
Force to_date(text,text) to return null with empty string

### DIFF
--- a/datefce.c
+++ b/datefce.c
@@ -611,6 +611,13 @@ ora_to_date(PG_FUNCTION_ARGS)
 		text *fmt_txt = PG_GETARG_TEXT_PP(1);
 		Datum newDate;
 
+		/*
+		 * With Oracle passing en empty string to to_date(txt, fmt) returns
+		 * NULL, PostgreSQL returns 0001-01-01 BC whatever is the format.
+		 */
+		if (strlen(text_to_cstring(date_txt)) == 0)
+			PG_RETURN_NULL();
+
 		/* it will return timestamp at GMT */
 		newDate = DirectFunctionCall2(to_timestamp,
 					      PointerGetDatum(date_txt),

--- a/expected/orafce.out
+++ b/expected/orafce.out
@@ -2614,6 +2614,12 @@ SELECT to_date('2009-01-02');
  2009-01-02 00:00:00
 (1 row)
 
+SELECT to_date('', 'yyyy-mm-dd');
+    to_date    
+---------------
+ 0001-01-01 BC
+(1 row)
+
 SELECT to_date('112012', 'J');
     to_date    
 ---------------
@@ -2624,6 +2630,12 @@ SELECT to_date('1003/03/15', 'yyyy/mm/dd');
   to_date   
 ------------
  1003-03-15
+(1 row)
+
+SELECT oracle.to_date('', 'yyyy-mm-dd');
+ to_date 
+---------
+ 
 (1 row)
 
 SELECT oracle.to_date('112012', 'J');

--- a/sql/orafce.sql
+++ b/sql/orafce.sql
@@ -542,8 +542,10 @@ SELECT to_number(1210::bigint, 9999::bigint);
 SELECT to_number(1210.73::numeric, 9999.99::numeric);
 
 SELECT to_date('2009-01-02');
+SELECT to_date('', 'yyyy-mm-dd');
 SELECT to_date('112012', 'J');
 SELECT to_date('1003/03/15', 'yyyy/mm/dd');
+SELECT oracle.to_date('', 'yyyy-mm-dd');
 SELECT oracle.to_date('112012', 'J');
 SELECT oracle.to_date('1003-03-15', 'yyyy-mm-dd');
 SET orafce.oracle_compatibility_date_limit TO off;


### PR DESCRIPTION
With Oracle passing en empty string to the to_date(txt, fmt) function returns NULL whereas PostgreSQL returns '0001-01-01 BC'. This true whatever is the format passed as second argument.

PostgreSQL + orafce without the patch:
```
gilles=# SELECT oracle.to_date('', 'YYYY-MM-DD');
    to_date    
---------------
 0001-01-01 BC
(1 row)
```

Oracle
```
SQL> SELECT to_date('', 'J') FROM DUAL;

TO_DATE('
---------

```

This patch change the behavior of the function oracle.to_date(txt, fmt) to mimic Oracle.
```
gilles=# SELECT oracle.to_date('', 'YYYY-MM-DD');
 to_date 
---------
 
(1 row)
```