### PR TITLE
Add support to nvl(double precision, integer) and to_date(integer, text)

### DIFF
--- a/orafce--4.13--4.14.sql
+++ b/orafce--4.13--4.14.sql
@@ -1,0 +1,10 @@
+CREATE OR REPLACE FUNCTION oracle.nvl(double precision, int)
+RETURNS bigint AS $$
+SELECT coalesce($1, $2)
+$$ LANGUAGE sql IMMUTABLE PARALLEL SAFE;
+
+CREATE FUNCTION oracle.to_date(integer, TEXT)
+RETURNS oracle.date
+AS $$ SELECT oracle.orafce__obsolete_to_date($1::text, $2)::oracle.date; $$
+LANGUAGE SQL STABLE STRICT PARALLEL SAFE;
+

--- a/orafce--4.14.sql
+++ b/orafce--4.14.sql
@@ -496,6 +496,11 @@ RETURNS oracle.date
 AS $$ SELECT oracle.orafce__obsolete_to_date($1, $2)::oracle.date; $$
 LANGUAGE SQL STABLE STRICT PARALLEL SAFE;
 
+CREATE FUNCTION oracle.to_date(integer, TEXT)
+RETURNS oracle.date
+AS $$ SELECT oracle.orafce__obsolete_to_date($1::text, $2)::oracle.date; $$
+LANGUAGE SQL STABLE STRICT PARALLEL SAFE;
+
 CREATE FUNCTION oracle.to_char(timestamp)
 RETURNS TEXT
 AS 'MODULE_PATHNAME','orafce_to_char_timestamp'
@@ -3608,6 +3613,11 @@ $$ LANGUAGE sql IMMUTABLE PARALLEL SAFE;
 
 CREATE OR REPLACE FUNCTION oracle.nvl(int, int)
 RETURNS int AS $$
+SELECT coalesce($1, $2)
+$$ LANGUAGE sql IMMUTABLE PARALLEL SAFE;
+
+CREATE OR REPLACE FUNCTION oracle.nvl(double precision, int)
+RETURNS bigint AS $$
 SELECT coalesce($1, $2)
 $$ LANGUAGE sql IMMUTABLE PARALLEL SAFE;
 

--- a/orafce.control
+++ b/orafce.control
@@ -1,5 +1,5 @@
 # orafce extension
 comment = 'Functions and operators that emulate a subset of functions and packages from the Oracle RDBMS'
-default_version = '4.13'
+default_version = '4.14'
 module_pathname = '$libdir/orafce'
 relocatable = false


### PR DESCRIPTION
Also increase version to 4.14

The use of to_date with an integer as first parameter is required when using the 'J' format.

Close #288