### PR TITLE
Try enhancing "DBMS_RANDOM.VALUE(low, high)"

### DIFF
--- a/expected/dbms_random.out
+++ b/expected/dbms_random.out
@@ -83,6 +83,18 @@ SELECT dbms_random.value(10,15)::numeric(10, 8);
  10.23233882
 (1 row)
 
+SELECT dbms_random.value(10,10)::numeric(10, 8);
+    value    
+-------------
+ 10.00000000
+(1 row)
+
+SELECT dbms_random.value(15,10)::numeric(10, 8);
+    value    
+-------------
+ 14.96377612
+(1 row)
+
 SELECT dbms_random.terminate();
  terminate 
 -----------
@@ -92,31 +104,31 @@ SELECT dbms_random.terminate();
 SELECT dbms_random.string('u', 10);
    string   
 ------------
- ZCDCHLMXAH
+ CDCHLMXAHZ
 (1 row)
 
 SELECT dbms_random.string('l', 10);
    string   
 ------------
- zfkgjhkghl
+ fkgjhkghll
 (1 row)
 
 SELECT dbms_random.string('a', 10);
    string   
 ------------
- xodQYutYyH
+ odQYutYyHa
 (1 row)
 
 SELECT dbms_random.string('x', 10);
    string   
 ------------
- 0GQ5J0M1WM
+ GQ5J0M1WMB
 (1 row)
 
 SELECT dbms_random.string('p', 10);
    string   
 ------------
- hX"|=i1&/h
+ X"|=i1&/h`
 (1 row)
 
 SELECT dbms_random.string('uu', 10); -- error
@@ -124,6 +136,6 @@ ERROR:  this first parameter value is more than 1 characters long
 SELECT dbms_random.string('w', 10);
    string   
 ------------
- AXPCTOMDNY
+ XPCTOMDNYT
 (1 row)
 

--- a/random.c
+++ b/random.c
@@ -293,14 +293,20 @@ dbms_random_value(PG_FUNCTION_ARGS)
 Datum
 dbms_random_value_range(PG_FUNCTION_ARGS)
 {
-	float8 low = PG_GETARG_FLOAT8(0);
-	float8 high = PG_GETARG_FLOAT8(1);
+	float8 arg_low = PG_GETARG_FLOAT8(0);
+	float8 arg_high = PG_GETARG_FLOAT8(1);
 	float8 result;
 
-	if (low > high)
-		PG_RETURN_NULL();
-
-	result = ((double) rand() / ((double) RAND_MAX + 1)) * ( high -  low) + low;
+	if (arg_low == arg_high)
+		result = arg_high;
+	else if (arg_low < arg_high)
+		result = ((double) rand() / ((double) RAND_MAX + 1)) * (arg_high -  arg_low) + arg_low;
+	else
+	{
+		float8 low = arg_high;
+		float8 high = arg_low;
+		result = ((double) rand() / ((double) RAND_MAX + 1)) * (high -  low) + low;
+	}
 
 	PG_RETURN_FLOAT8(result);
 }

--- a/sql/dbms_random.sql
+++ b/sql/dbms_random.sql
@@ -13,6 +13,8 @@ SELECT dbms_random.string('l',3);
 SELECT dbms_random.seed(5);
 SELECT dbms_random.value()::numeric(10, 8);
 SELECT dbms_random.value(10,15)::numeric(10, 8);
+SELECT dbms_random.value(10,10)::numeric(10, 8);
+SELECT dbms_random.value(15,10)::numeric(10, 8);
 SELECT dbms_random.terminate();
 
 SELECT dbms_random.string('u', 10);


### PR DESCRIPTION
Try enhancing "DBMS_RANDOM.VALUE(low, high)", which does not behave exactly the same in the Oracle database as it does in the oracle documentation.

### documentation
![image](https://github.com/user-attachments/assets/ff638eb9-b408-4533-a386-bfc7c22122a4)

### behavior
![image](https://github.com/user-attachments/assets/11d4b09a-89fb-4d75-8d69-815cce0e8efd)

Maybe it's a doc bug, but I'm not sure, emmm