### PR TITLE
Fixed incorrect length checking

### DIFF
--- a/file.c
+++ b/file.c
@@ -169,7 +169,7 @@ orafce_umask_check_hook(char **newval, void **extra, GucSource source)
 			GUC_check_errdetail("invalid octal digit");
 			return false;
 		}
-
+		digits++;
 		if (digits > 3)
 		{
 			GUC_check_errdetail("number is too big (only four digits are allowed");


### PR DESCRIPTION
Added missing increment of digit counter, the checking of digits was always false.

Found by PostgresPro
Fixes: ae9d030 ("Allow to set umask for utl_file.fopen by setting orafce.umask. This setting is allowed only for user with rights of role orafce_set_umask.")
Signed-off-by: Maksim Korotkov <m.korotkov@postgrespro.ru>