### PR TITLE
Fix pg_upgrade failure after updating orafce from version 3.13 or earlier to 3.14 or later.

### DIFF
--- a/orafce--3.13--3.14.sql
+++ b/orafce--3.13--3.14.sql
@@ -6,29 +6,27 @@ LANGUAGE 'c';
 do $$
 BEGIN
   IF EXISTS(SELECT * FROM pg_settings WHERE name = 'server_version_num' AND setting::int >= 120000) THEN
-    EXECUTE $_$ALTER FUNCTION varchar2(varchar2, integer, boolean) SUPPORT varchar2_transform$_$;
+    UPDATE pg_proc SET prosupport= 'varchar2_transform'::regproc::oid WHERE proname='varchar2';
   ELSE
     UPDATE pg_proc SET protransform= 'varchar2_transform'::regproc::oid WHERE proname='varchar2';
-
-    INSERT INTO pg_depend (classid, objid, objsubid,
-                           refclassid, refobjid, refobjsubid, deptype)
-       VALUES('pg_proc'::regclass::oid, 'varchar2'::regproc::oid, 0,
-              'pg_proc'::regclass::oid, 'varchar2_transform'::regproc::oid, 0, 'n');
   END IF;
+  INSERT INTO pg_depend (classid, objid, objsubid,
+                         refclassid, refobjid, refobjsubid, deptype)
+     VALUES('pg_proc'::regclass::oid, 'varchar2'::regproc::oid, 0,
+            'pg_proc'::regclass::oid, 'varchar2_transform'::regproc::oid, 0, 'n');
 END
 $$;
 
 do $$
 BEGIN
   IF EXISTS(SELECT * FROM pg_settings WHERE name = 'server_version_num' AND setting::int >= 120000) THEN
-    EXECUTE $_$ALTER FUNCTION nvarchar2(nvarchar2, integer, boolean) SUPPORT nvarchar2_transform$_$;
+    UPDATE pg_proc SET prosupport= 'nvarchar2_transform'::regproc::oid WHERE proname='nvarchar2';
   ELSE
     UPDATE pg_proc SET protransform= 'nvarchar2_transform'::regproc::oid WHERE proname='nvarchar2';
-
-    INSERT INTO pg_depend (classid, objid, objsubid,
-                           refclassid, refobjid, refobjsubid, deptype)
-       VALUES('pg_proc'::regclass::oid, 'nvarchar2'::regproc::oid, 0,
-              'pg_proc'::regclass::oid, 'nvarchar2_transform'::regproc::oid, 0, 'n');
   END IF;
+  INSERT INTO pg_depend (classid, objid, objsubid,
+                         refclassid, refobjid, refobjsubid, deptype)
+     VALUES('pg_proc'::regclass::oid, 'nvarchar2'::regproc::oid, 0,
+            'pg_proc'::regclass::oid, 'nvarchar2_transform'::regproc::oid, 0, 'n');
 END
 $$;


### PR DESCRIPTION
### Issue Summary

pg_upgrade fails when orafce 3.13 has already been installed in PostgreSQL 12 or later.

When I use orafce 3.13 or earlier with PostgreSQL major version 12 and run pg_upgrade after updating to orafce version 3.14 or higher, that pg_upgrade fails with following error. This appears to be an orafce bug in older versions.

```
pg_restore: creating FUNCTION "public.nvarchar2("public"."nvarchar2", integer, boolean)"
pg_restore: while PROCESSING TOC:
pg_restore: from TOC entry 610; 1255 16822 FUNCTION nvarchar2("public"."nvarchar2", integer, boolean) postgres
pg_restore: error: could not execute query: ERROR:  function public.nvarchar2_transform(internal) does not exist
Command was: CREATE FUNCTION "public"."nvarchar2"("public"."nvarchar2", integer, boolean) RETURNS "public"."nvarchar2"
    LANGUAGE "c" IMMUTABLE STRICT SUPPORT "public"."nvarchar2_transform"
    AS '$libdir/orafce', 'nvarchar2';

-- For binary upgrade, handle extension membership the hard way
ALTER EXTENSION "orafce" ADD FUNCTION "public"."nvarchar2"("public"."nvarchar2", integer, boolean);
```

### How to reproduce this issue

1. Install PostgreSQL 12.22 with orafce version 3.13.
2. Update orafce version from 3.13 to 3.14 or later.
3. Upgrade PostgreSQL by using pg_upgrade, I got following error. pg_upgrade_dump_13678.log file has above error.
```
...
Setting frozenxid and minmxid counters in new cluster         ok
Restoring global objects in the new cluster                   ok
Restoring database schemas in the new cluster
  postgres
*failure*

Consult the last few lines of "/home/postgres/pgsql_16/data/pg_upgrade_output.d/20250602T052032.629/log/pg_upgrade_dump_13678.log" for
the probable cause of the failure.
Failure, exiting
```

### My investigation

This error is the same as the issue https://github.com/orafce/orafce/issues/124 . This issue should have been fixed in commit fc9f00e, but it seems like some use cases will still cause issues.

In this commit, trying to create dependencies by running "ALTER FUNCTION ... SUPPORT ..." for PostgreSQL 12 or later versions.
```
  IF EXISTS(SELECT * FROM pg_settings WHERE name = 'server_version_num' AND setting::int >= 120000) THEN
    ALTER FUNCTION varchar2(varchar2, integer, boolean) SUPPORT varchar2_transform;
```

This commit seems to work when installing new orafce extension. The PostgreSQL upgrade by pg_upgrade completed successfully, even in my environment.
However, when orafce 3.13 or earlier was already installed and the orafce version was updated by running "ALTER EXTENSION orafce UPDATE", it did not work well.
If orafce 3.13 has already been installed, prosupport column at pg_proc has been updated with UPDATE statement manually, which causes half-baked dependency. As a result, no entries were created for pg_depend by "ALTER FUNCTION ... SUPPORT ..." in "ALTER EXTENSION orafce UPDATE" process.

https://github.com/orafce/orafce/blob/VERSION_3_13_4/orafce--3.13.sql#L2286-L2294
```
do $$
BEGIN
  IF EXISTS(SELECT * FROM pg_settings WHERE name = 'server_version_num' AND setting::int >= 120000) THEN
    UPDATE pg_proc SET prosupport='nvarchar2_transform'::regproc::oid WHERE proname='nvarchar2';
  ELSE
    UPDATE pg_proc SET protransform='nvarchar2_transform'::regproc::oid WHERE proname='nvarchar2';
  END IF;
END
$$;
```

-----

In this PR, I changed orafce--3.13--3.14.sql to execute INSERT entries into pg_depend even if PostgreSQL version 12 or later too. 
