### PR TITLE
Oracle accepts return_opt value greater than 1 in regexp_instr

### DIFF
--- a/regexp.c
+++ b/regexp.c
@@ -965,10 +965,14 @@ orafce_regexp_instr(PG_FUNCTION_ARGS)
 			PG_RETURN_NULL();
 
 		endoption = PG_GETARG_INT32(4);
-		if (endoption != 0 && endoption != 1)
+		if (endoption < 0)
 			ereport(ERROR,
 					(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-					 errmsg("argument 'return_opt' must be 0 or 1")));
+					 errmsg("argument 'return_opt' is out of range")));
+
+		/* Reset value greater than 1 */
+		if (endoption > 0)
+			endoption = 1;
 	}
 	if (PG_NARGS() > 5)
 	{


### PR DESCRIPTION
Oracle treat value of 'return_opt' greater than 1 as 1 instead of throwing error like PostgreSQL where value could only be 0 or 1.