### PR TITLE
test: add alternative expected output for dbms_random on macOS ARM

### DIFF
--- a/expected/dbms_random_3.out
+++ b/expected/dbms_random_3.out
@@ -1,0 +1,149 @@
+-- Tests for package DBMS_RANDOM
+SELECT dbms_random.initialize(8);
+ initialize 
+------------
+ 
+(1 row)
+
+SELECT dbms_random.normal()::numeric(10, 8);
+   normal    
+-------------
+ -3.83566924
+(1 row)
+
+SELECT dbms_random.normal()::numeric(10, 8);
+   normal    
+-------------
+ -1.62292887
+(1 row)
+
+SELECT dbms_random.seed(8);
+ seed 
+------
+ 
+(1 row)
+
+SELECT dbms_random.random();
+   random    
+-------------
+ -2147214734
+(1 row)
+
+SELECT dbms_random.seed('test');
+ seed 
+------
+ 
+(1 row)
+
+SELECT dbms_random.string('U',5);
+ string 
+--------
+ TPZXT
+(1 row)
+
+SELECT dbms_random.string('P',2);
+ string 
+--------
+ 3a
+(1 row)
+
+SELECT dbms_random.string('x',4);
+ string 
+--------
+ ZCHL
+(1 row)
+
+SELECT dbms_random.string('a',2);
+ string 
+--------
+ Hm
+(1 row)
+
+SELECT dbms_random.string('l',3);
+ string 
+--------
+ sdq
+(1 row)
+
+SELECT dbms_random.seed(5);
+ seed 
+------
+ 
+(1 row)
+
+SELECT dbms_random.value()::numeric(10, 8);
+   value    
+------------
+ 0.00003913
+(1 row)
+
+SELECT dbms_random.value(10,15)::numeric(10, 8);
+    value    
+-------------
+ 13.28844470
+(1 row)
+
+SELECT dbms_random.value(10,10)::numeric(10, 8);
+    value    
+-------------
+ 10.00000000
+(1 row)
+
+SELECT dbms_random.value(15,10)::numeric(10, 8);
+    value    
+-------------
+ 11.46625330
+(1 row)
+
+SELECT dbms_random.seed(5);
+ seed 
+------
+ 
+(1 row)
+
+SELECT dbms_random.string('u', 10);
+   string   
+------------
+ ARUHRCGKKR
+(1 row)
+
+SELECT dbms_random.string('l', 10);
+   string   
+------------
+ xpeegqjbxi
+(1 row)
+
+SELECT dbms_random.string('a', 10);
+   string   
+------------
+ ewXHmHxoeA
+(1 row)
+
+SELECT dbms_random.string('x', 10);
+   string   
+------------
+ JTB8ON5SYT
+(1 row)
+
+SELECT dbms_random.string('p', 10);
+   string   
+------------
+ pBQD];eb;t
+(1 row)
+
+SELECT dbms_random.string('uu', 10); -- error
+ERROR:  this first parameter value is more than 1 characters long
+SELECT dbms_random.string('w', 10);
+   string   
+------------
+ VKEJUVLMOH
+(1 row)
+
+-- although it is useless, and deprecated on Oracle
+-- it should be last command
+SELECT dbms_random.terminate();
+ terminate 
+-----------
+ 
+(1 row)
+


### PR DESCRIPTION
### Description

Per discussion in #306, this PR adds an alternative expected output file for the `dbms_random` regression test.

The `rand()` implementation in libc on **macOS (Apple Silicon)** differs from Linux, causing regression failures due to different random number generation sequences, even with the same seed.

### Changes

* Added `expected/dbms_random_3.out` containing the output generated on macOS ARM64 (M2).
* Verified that `make installcheck` passes successfully with this addition.
<img width="1322" height="489" alt="image" src="https://github.com/user-attachments/assets/dc64433a-62b4-4e66-bcb0-d2858d9d96b1" />


### Related Issue
Closes #306