### PR TITLE
Fix compilation against PostgreSQL 19

### DIFF
--- a/alert.c
+++ b/alert.c
@@ -12,6 +12,7 @@
 #include "storage/procarray.h"
 #include "utils/builtins.h"
 #include "utils/timestamp.h"
+#include "portability/instr_time.h"
 
 #if PG_VERSION_NUM >= 140000
 

--- a/pipe.c
+++ b/pipe.c
@@ -12,6 +12,7 @@
 #include "utils/builtins.h"
 #include "utils/date.h"
 #include "utils/numeric.h"
+#include "portability/instr_time.h"
 
 #if PG_VERSION_NUM >= 140000
 

--- a/plvsubst.c
+++ b/plvsubst.c
@@ -98,7 +98,7 @@ plvsubst_string(text *template_in, ArrayType *vals_in, text *c_subst, FunctionCa
 
 #else
 
-	const bits8 *bitmap;
+	const uint8 *bitmap;
 
 #endif
 


### PR DESCRIPTION
PostgreSQL 19 removed the bits8 typedef and the instr_time API moved to a separate header.

- Replace bits8 with uint8 in plvsubst.c
- Add #include portability/instr_time.h in alert.c and pipe.c

for issue: https://github.com/orafce/orafce/issues/310