### PR TITLE
Add another alternative output for dbms_random test to make it pass on Big Endian machine.

### DIFF
--- a/expected/dbms_random_4.out
+++ b/expected/dbms_random_4.out
@@ -1,0 +1,149 @@
+-- Tests for package DBMS_RANDOM
+SELECT dbms_random.initialize(8);
+ initialize 
+------------
+ 
+(1 row)
+
+SELECT dbms_random.normal()::numeric(10, 8);
+   normal    
+-------------
+ -0.37787769
+(1 row)
+
+SELECT dbms_random.normal()::numeric(10, 8);
+   normal   
+------------
+ 0.80499804
+(1 row)
+
+SELECT dbms_random.seed(8);
+ seed 
+------
+ 
+(1 row)
+
+SELECT dbms_random.random();
+   random   
+------------
+ -632387854
+(1 row)
+
+SELECT dbms_random.seed('test');
+ seed 
+------
+ 
+(1 row)
+
+SELECT dbms_random.string('U',5);
+ string 
+--------
+ IGXBB
+(1 row)
+
+SELECT dbms_random.string('P',2);
+ string 
+--------
+ T`
+(1 row)
+
+SELECT dbms_random.string('x',4);
+ string 
+--------
+ P1CB
+(1 row)
+
+SELECT dbms_random.string('a',2);
+ string 
+--------
+ yV
+(1 row)
+
+SELECT dbms_random.string('l',3);
+ string 
+--------
+ ccw
+(1 row)
+
+SELECT dbms_random.seed(5);
+ seed 
+------
+ 
+(1 row)
+
+SELECT dbms_random.value()::numeric(10, 8);
+   value    
+------------
+ 0.27474560
+(1 row)
+
+SELECT dbms_random.value(10,15)::numeric(10, 8);
+    value    
+-------------
+ 10.23233882
+(1 row)
+
+SELECT dbms_random.value(10,10)::numeric(10, 8);
+    value    
+-------------
+ 10.00000000
+(1 row)
+
+SELECT dbms_random.value(15,10)::numeric(10, 8);
+    value    
+-------------
+ 10.40015223
+(1 row)
+
+SELECT dbms_random.seed(5);
+ seed 
+------
+ 
+(1 row)
+
+SELECT dbms_random.string('u', 10);
+   string   
+------------
+ HBZCDCHLMX
+(1 row)
+
+SELECT dbms_random.string('l', 10);
+   string   
+------------
+ ahzfkgjhkg
+(1 row)
+
+SELECT dbms_random.string('a', 10);
+   string   
+------------
+ pxxodQYutY
+(1 row)
+
+SELECT dbms_random.string('x', 10);
+   string   
+------------
+ HN0GQ5J0M1
+(1 row)
+
+SELECT dbms_random.string('p', 10);
+   string   
+------------
+ VEhX"|=i1&
+(1 row)
+
+SELECT dbms_random.string('uu', 10); -- error
+ERROR:  this first parameter value is more than 1 characters long
+SELECT dbms_random.string('w', 10);
+   string   
+------------
+ MIAXPCTOMD
+(1 row)
+
+-- although it is useless, and deprecated on Oracle
+-- it should be last command
+SELECT dbms_random.terminate();
+ terminate 
+-----------
+ 
+(1 row)
+


### PR DESCRIPTION
Recently I've been looking on dbms_random test failure on a Big Endian machine. My research ended in seeing a different behavior of `hash_bytes()` between Little Endian and Big Endian. This makes srand() get different seed despite having the same input bytes 'test' to `dbms_random_seed_varchar()`. I've asked a question in pgsql-hackers about `hash_bytes()` machine-independence (https://www.postgresql.org/message-id/flat/AS1PR01MB9347D394AC87A0C56FD8E3D2CD1A2%40AS1PR01MB9347.eurprd01.prod.exchangelabs.com) and I think the best way to handle this test failure is to add another alternative output relatable to Big Endian.