### PR TITLE
Add hextoraw/rawtohex, empty_clob/empty_blob and from_tz functions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ OBJS= regexp.o\
 
 EXTENSION = orafce
 
-DATA = orafce--4.16.sql\
+DATA = orafce--4.17.sql\
 		orafce--3.2--3.3.sql\
 		orafce--3.3--3.4.sql\
 		orafce--3.4--3.5.sql\
@@ -70,7 +70,8 @@ DATA = orafce--4.16.sql\
 		orafce--4.12--4.13.sql\
 		orafce--4.13--4.14.sql\
 		orafce--4.14--4.15.sql\
-		orafce--4.15--4.16.sql
+		orafce--4.15--4.16.sql\
+		orafce--4.16--4.17.sql
 
 
 DOCS = README.asciidoc COPYRIGHT.orafce INSTALL.orafce
@@ -91,7 +92,8 @@ REGRESS = orafce\
 		nlssort\
 		dbms_random\
 		regexp_func\
-		dbms_sql
+		dbms_sql\
+		hextoraw
 
 #REGRESS_OPTS = --load-language=plpgsql --schedule=parallel_schedule --encoding=utf8
 REGRESS_OPTS = --schedule=parallel_schedule --encoding=utf8

--- a/expected/hextoraw.out
+++ b/expected/hextoraw.out
@@ -1,0 +1,183 @@
+-- Test for hextoraw()/rawtohex(), empty_clob()/empty_blob() and from_tz()
+\set ECHO none
+SET search_path TO oracle, "$user", public, pg_catalog;
+----
+-- hextoraw() / rawtohex() -- inverse hex <-> raw (bytea) pair
+----
+-- ORACLE> SELECT hextoraw('4142') FROM dual; -> 4142  (the raw bytes 0x41 0x42)
+SELECT hextoraw('4142');
+ hextoraw 
+----------
+ \x4142
+(1 row)
+
+-- input hex is case-insensitive
+SELECT hextoraw('deadbeef');
+  hextoraw  
+------------
+ \xdeadbeef
+(1 row)
+
+SELECT hextoraw('DEADBEEF');
+  hextoraw  
+------------
+ \xdeadbeef
+(1 row)
+
+SELECT hextoraw('deadbeef') = hextoraw('DEADBEEF');
+ ?column? 
+----------
+ t
+(1 row)
+
+-- empty input yields an empty raw
+SELECT hextoraw('');
+ hextoraw 
+----------
+ \x
+(1 row)
+
+-- ORACLE> SELECT rawtohex(utl_raw.cast_to_raw('AB')) FROM dual; -> 4142
+-- rawtohex yields UPPER-case hex, as Oracle does
+SELECT rawtohex('\xdeadbeef'::bytea);
+ rawtohex 
+----------
+ DEADBEEF
+(1 row)
+
+SELECT rawtohex('\x4142'::bytea);
+ rawtohex 
+----------
+ 4142
+(1 row)
+
+SELECT rawtohex(''::bytea);
+ rawtohex 
+----------
+ 
+(1 row)
+
+-- the two are inverses (round-trips, both directions)
+SELECT rawtohex(hextoraw('DEADBEEF'));
+ rawtohex 
+----------
+ DEADBEEF
+(1 row)
+
+SELECT hextoraw(rawtohex('\x0123456789abcdef'::bytea));
+      hextoraw      
+--------------------
+ \x0123456789abcdef
+(1 row)
+
+----
+-- empty_clob() / empty_blob() -- empty character / binary LOBs
+----
+-- ORACLE> SELECT empty_clob() FROM dual; -> (empty)
+SELECT empty_clob();
+ empty_clob 
+------------
+ 
+(1 row)
+
+SELECT empty_clob() IS NULL;
+ ?column? 
+----------
+ f
+(1 row)
+
+SELECT length(empty_clob());
+ length 
+--------
+      0
+(1 row)
+
+SELECT empty_clob() = '';
+ ?column? 
+----------
+ t
+(1 row)
+
+-- ORACLE> SELECT empty_blob() FROM dual; -> (empty)
+SELECT empty_blob();
+ empty_blob 
+------------
+ \x
+(1 row)
+
+SELECT empty_blob() IS NULL;
+ ?column? 
+----------
+ f
+(1 row)
+
+SELECT length(empty_blob());
+ length 
+--------
+      0
+(1 row)
+
+SELECT empty_blob() = ''::bytea;
+ ?column? 
+----------
+ t
+(1 row)
+
+----
+-- from_tz() -- read a naive timestamp as being in the given zone
+----
+-- Display the result in a fixed session zone so the point-in-time is stable.
+SET TimeZone TO 'UTC';
+-- A numeric offset follows the ISO sign convention (east of UTC is positive),
+-- as Oracle does -- NOT PostgreSQL's inverted POSIX sign.
+-- ORACLE> SELECT from_tz(TIMESTAMP '2005-04-12 13:00:00', '+02:00') FROM dual;
+--         -> 2005-04-12 13:00:00.000000 +02:00  (i.e. 11:00 UTC)
+SELECT from_tz(TIMESTAMP '2005-04-12 13:00:00', '+02:00');
+           from_tz            
+------------------------------
+ Tue Apr 12 11:00:00 2005 UTC
+(1 row)
+
+-- ORACLE> SELECT from_tz(TIMESTAMP '2005-04-12 13:00:00', '-05:00') FROM dual;
+--         -> 2005-04-12 13:00:00.000000 -05:00  (i.e. 18:00 UTC)
+SELECT from_tz(TIMESTAMP '2005-04-12 13:00:00', '-05:00');
+           from_tz            
+------------------------------
+ Tue Apr 12 18:00:00 2005 UTC
+(1 row)
+
+-- a fractional-hour offset
+SELECT from_tz(TIMESTAMP '2005-04-12 13:00:00', '+05:30');
+           from_tz            
+------------------------------
+ Tue Apr 12 07:30:00 2005 UTC
+(1 row)
+
+-- a named region resolves against the live zone database
+SELECT from_tz(TIMESTAMP '2005-01-15 12:00:00', 'Europe/Prague');
+           from_tz            
+------------------------------
+ Sat Jan 15 11:00:00 2005 UTC
+(1 row)
+
+SELECT from_tz(TIMESTAMP '2005-07-15 12:00:00', 'Europe/Prague');
+           from_tz            
+------------------------------
+ Fri Jul 15 10:00:00 2005 UTC
+(1 row)
+
+-- UTC in, UTC out is a no-op
+SELECT from_tz(TIMESTAMP '2005-04-12 13:00:00', 'UTC');
+           from_tz            
+------------------------------
+ Tue Apr 12 13:00:00 2005 UTC
+(1 row)
+
+-- from_tz is the inverse of the existing sys_extract_utc()
+SELECT sys_extract_utc(from_tz(TIMESTAMP '2005-04-12 13:00:00', '+02:00'));
+     sys_extract_utc      
+--------------------------
+ Tue Apr 12 11:00:00 2005
+(1 row)
+
+RESET TimeZone;

--- a/orafce--4.16--4.17.sql
+++ b/orafce--4.16--4.17.sql
@@ -1,0 +1,38 @@
+CREATE FUNCTION oracle.hextoraw(text)
+RETURNS bytea
+AS $$ SELECT decode($1, 'hex') $$
+LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE;
+COMMENT ON FUNCTION oracle.hextoraw(text) IS 'Converts a string of hexadecimal digits to a raw (bytea) value';
+
+CREATE FUNCTION oracle.rawtohex(bytea)
+RETURNS text
+AS $$ SELECT upper(encode($1, 'hex')) $$
+LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE;
+COMMENT ON FUNCTION oracle.rawtohex(bytea) IS 'Converts a raw (bytea) value to a string of hexadecimal digits';
+
+CREATE FUNCTION oracle.empty_clob()
+RETURNS text
+AS $$ SELECT ''::text $$
+LANGUAGE sql IMMUTABLE PARALLEL SAFE;
+COMMENT ON FUNCTION oracle.empty_clob() IS 'Returns an empty character LOB';
+
+CREATE FUNCTION oracle.empty_blob()
+RETURNS bytea
+AS $$ SELECT ''::bytea $$
+LANGUAGE sql IMMUTABLE PARALLEL SAFE;
+COMMENT ON FUNCTION oracle.empty_blob() IS 'Returns an empty binary LOB';
+
+CREATE FUNCTION oracle.from_tz(timestamp, text)
+RETURNS timestamp with time zone
+AS $$
+    -- A numeric offset ('+02:00') is applied as an interval so it follows the
+    -- ISO sign convention (east of UTC is positive), as Oracle does; passing it
+    -- straight to AT TIME ZONE as text would use PostgreSQL's inverted POSIX
+    -- sign. A region name ('Europe/Prague') is looked up in the zone database.
+    SELECT CASE
+        WHEN $2 ~ '^[+-]?[0-9]{1,2}:[0-9]{2}$' THEN $1 AT TIME ZONE ($2)::interval
+        ELSE $1 AT TIME ZONE $2
+    END
+$$
+LANGUAGE sql STABLE STRICT PARALLEL SAFE;
+COMMENT ON FUNCTION oracle.from_tz(timestamp, text) IS 'Interprets a timestamp as being in the given time zone and returns a timestamp with time zone';

--- a/orafce--4.17.sql
+++ b/orafce--4.17.sql
@@ -538,6 +538,45 @@ AS 'MODULE_PATHNAME','orafce_sys_extract_utc_oracle_date'
 LANGUAGE C STABLE STRICT PARALLEL SAFE;
 COMMENT ON FUNCTION oracle.sysdate() IS 'Extract timestamp at utc time zone';
 
+CREATE FUNCTION oracle.from_tz(timestamp, text)
+RETURNS timestamp with time zone
+AS $$
+    -- A numeric offset ('+02:00') is applied as an interval so it follows the
+    -- ISO sign convention (east of UTC is positive), as Oracle does; passing it
+    -- straight to AT TIME ZONE as text would use PostgreSQL's inverted POSIX
+    -- sign. A region name ('Europe/Prague') is looked up in the zone database.
+    SELECT CASE
+        WHEN $2 ~ '^[+-]?[0-9]{1,2}:[0-9]{2}$' THEN $1 AT TIME ZONE ($2)::interval
+        ELSE $1 AT TIME ZONE $2
+    END
+$$
+LANGUAGE sql STABLE STRICT PARALLEL SAFE;
+COMMENT ON FUNCTION oracle.from_tz(timestamp, text) IS 'Interprets a timestamp as being in the given time zone and returns a timestamp with time zone';
+
+CREATE FUNCTION oracle.hextoraw(text)
+RETURNS bytea
+AS $$ SELECT decode($1, 'hex') $$
+LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE;
+COMMENT ON FUNCTION oracle.hextoraw(text) IS 'Converts a string of hexadecimal digits to a raw (bytea) value';
+
+CREATE FUNCTION oracle.rawtohex(bytea)
+RETURNS text
+AS $$ SELECT upper(encode($1, 'hex')) $$
+LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE;
+COMMENT ON FUNCTION oracle.rawtohex(bytea) IS 'Converts a raw (bytea) value to a string of hexadecimal digits';
+
+CREATE FUNCTION oracle.empty_clob()
+RETURNS text
+AS $$ SELECT ''::text $$
+LANGUAGE sql IMMUTABLE PARALLEL SAFE;
+COMMENT ON FUNCTION oracle.empty_clob() IS 'Returns an empty character LOB';
+
+CREATE FUNCTION oracle.empty_blob()
+RETURNS bytea
+AS $$ SELECT ''::bytea $$
+LANGUAGE sql IMMUTABLE PARALLEL SAFE;
+COMMENT ON FUNCTION oracle.empty_blob() IS 'Returns an empty binary LOB';
+
 CREATE FUNCTION oracle.months_between(date1 oracle.date, date2 oracle.date)
 RETURNS numeric
 AS 'MODULE_PATHNAME', 'months_between_timestamp'

--- a/orafce.control
+++ b/orafce.control
@@ -1,5 +1,5 @@
 # orafce extension
 comment = 'Functions and operators that emulate a subset of functions and packages from the Oracle RDBMS'
-default_version = '4.16'
+default_version = '4.17'
 module_pathname = '$libdir/orafce'
 relocatable = false

--- a/sql/hextoraw.sql
+++ b/sql/hextoraw.sql
@@ -1,0 +1,74 @@
+-- Test for hextoraw()/rawtohex(), empty_clob()/empty_blob() and from_tz()
+\set ECHO none
+SET client_min_messages = warning;
+SET client_encoding = utf8;
+\set VERBOSITY terse
+\set ECHO all
+
+SET search_path TO oracle, "$user", public, pg_catalog;
+
+----
+-- hextoraw() / rawtohex() -- inverse hex <-> raw (bytea) pair
+----
+
+-- ORACLE> SELECT hextoraw('4142') FROM dual; -> 4142  (the raw bytes 0x41 0x42)
+SELECT hextoraw('4142');
+-- input hex is case-insensitive
+SELECT hextoraw('deadbeef');
+SELECT hextoraw('DEADBEEF');
+SELECT hextoraw('deadbeef') = hextoraw('DEADBEEF');
+-- empty input yields an empty raw
+SELECT hextoraw('');
+
+-- ORACLE> SELECT rawtohex(utl_raw.cast_to_raw('AB')) FROM dual; -> 4142
+-- rawtohex yields UPPER-case hex, as Oracle does
+SELECT rawtohex('\xdeadbeef'::bytea);
+SELECT rawtohex('\x4142'::bytea);
+SELECT rawtohex(''::bytea);
+
+-- the two are inverses (round-trips, both directions)
+SELECT rawtohex(hextoraw('DEADBEEF'));
+SELECT hextoraw(rawtohex('\x0123456789abcdef'::bytea));
+
+----
+-- empty_clob() / empty_blob() -- empty character / binary LOBs
+----
+
+-- ORACLE> SELECT empty_clob() FROM dual; -> (empty)
+SELECT empty_clob();
+SELECT empty_clob() IS NULL;
+SELECT length(empty_clob());
+SELECT empty_clob() = '';
+
+-- ORACLE> SELECT empty_blob() FROM dual; -> (empty)
+SELECT empty_blob();
+SELECT empty_blob() IS NULL;
+SELECT length(empty_blob());
+SELECT empty_blob() = ''::bytea;
+
+----
+-- from_tz() -- read a naive timestamp as being in the given zone
+----
+
+-- Display the result in a fixed session zone so the point-in-time is stable.
+SET TimeZone TO 'UTC';
+
+-- A numeric offset follows the ISO sign convention (east of UTC is positive),
+-- as Oracle does -- NOT PostgreSQL's inverted POSIX sign.
+-- ORACLE> SELECT from_tz(TIMESTAMP '2005-04-12 13:00:00', '+02:00') FROM dual;
+--         -> 2005-04-12 13:00:00.000000 +02:00  (i.e. 11:00 UTC)
+SELECT from_tz(TIMESTAMP '2005-04-12 13:00:00', '+02:00');
+-- ORACLE> SELECT from_tz(TIMESTAMP '2005-04-12 13:00:00', '-05:00') FROM dual;
+--         -> 2005-04-12 13:00:00.000000 -05:00  (i.e. 18:00 UTC)
+SELECT from_tz(TIMESTAMP '2005-04-12 13:00:00', '-05:00');
+-- a fractional-hour offset
+SELECT from_tz(TIMESTAMP '2005-04-12 13:00:00', '+05:30');
+-- a named region resolves against the live zone database
+SELECT from_tz(TIMESTAMP '2005-01-15 12:00:00', 'Europe/Prague');
+SELECT from_tz(TIMESTAMP '2005-07-15 12:00:00', 'Europe/Prague');
+-- UTC in, UTC out is a no-op
+SELECT from_tz(TIMESTAMP '2005-04-12 13:00:00', 'UTC');
+-- from_tz is the inverse of the existing sys_extract_utc()
+SELECT sys_extract_utc(from_tz(TIMESTAMP '2005-04-12 13:00:00', '+02:00'));
+
+RESET TimeZone;


### PR DESCRIPTION
Five Oracle-compatible scalar functions orafce did not yet provide, added in the oracle schema as pure-SQL, following the same version-bump scheme as the nvl/to_date additions (a new orafce--4.16--4.17.sql migration, the base file renamed to orafce--4.17.sql with the same definitions, orafce.control and the Makefile DATA list bumped to 4.17):

* hextoraw(text) / rawtohex(bytea) -- an inverse pair converting between a hex string and a raw (bytea) value; rawtohex yields upper-case hex, as Oracle does.
* empty_clob() / empty_blob() -- return an empty character / binary LOB.
* from_tz(timestamp, text) -- interpret a naive timestamp as being in the given time zone, returning a timestamp with time zone. This is the inverse of the existing sys_extract_utc(), resolving a named region's offset from the live zone database.

Verified on PostgreSQL 16: a fresh CREATE EXTENSION lands on 4.17 with the functions, and an ALTER EXTENSION orafce UPDATE TO '4.17' from 4.16 applies the migration cleanly.