### PR TITLE
regexp.c: guard pg_re_flags for forks that hoist it into regex.h

### DIFF
--- a/regexp.c
+++ b/regexp.c
@@ -17,12 +17,31 @@
 #include "orafce.h"
 #include "builtins.h"
 
-/* all the options of interest for regex functions */
+/*
+ * all the options of interest for regex functions
+ *
+ * Some PostgreSQL forks (e.g. IvorySQL, as of at least 4.6) hoist this
+ * struct out of utils/adt/regexp.c and into regex/regex.h, which we already
+ * include above, so that their own Oracle-compatibility regex functions can
+ * share it. Defining it again here is then a hard redefinition error:
+ *
+ *   regexp.c:21:16: error: redefinition of 'pg_re_flags'
+ *   regexp.c:25:3: error: typedef redefinition with different types
+ *     .../regex/regex.h:253:3: note: previous definition is here
+ *
+ * There's no portable way to detect this at compile time (the fork does
+ * not define a distinguishing macro that reliably survives into
+ * pg_config.h across its own released versions), so builds against such a
+ * fork need to pass -DORAFCE_PG_RE_FLAGS_IN_REGEX_H explicitly, e.g. via
+ * PG_CPPFLAGS. On vanilla PostgreSQL nothing changes.
+ */
+#ifndef ORAFCE_PG_RE_FLAGS_IN_REGEX_H
 typedef struct pg_re_flags
 {
 	int			cflags;			/* compile flags for Spencer's regex code */
 	bool		glob;			/* do it globally (for each occurrence) */
 } pg_re_flags;
+#endif
 
 /* cross-call state for regexp_match and regexp_split functions */
 typedef struct regexp_matches_ctx


### PR DESCRIPTION
Some PostgreSQL forks (IvorySQL, at least as of 4.6) move the `pg_re_flags` struct out of `utils/adt/regexp.c` and into their own `regex/regex.h` — which `regexp.c` already includes — so their own Oracle-compatibility regex functions can share it. That turns orafce's local typedef of the same name into a hard redefinition error when co-building against such a fork's headers:

```
regexp.c:21:16: error: redefinition of 'pg_re_flags'
regexp.c:25:3: error: typedef redefinition with different types
  .../regex/regex.h:253:3: note: previous definition is here
```

Fix: guard the local typedef behind `-DORAFCE_PG_RE_FLAGS_IN_REGEX_H`, left undefined by default so nothing changes for a normal build. A build that's integrating orafce with such a fork passes the flag (e.g. via `PG_CPPFLAGS`) to skip the now-redundant local definition. A configure-time auto-detect wasn't possible here — the fork in question doesn't reliably expose a distinguishing macro through `pg_config.h` across its own released versions — so this is an opt-in flag rather than automatic.

**Tested:**
- Reproduced the exact error above compiling `regexp.c` against a real IvorySQL 4.6 build's headers (unpatched).
- Patched + `-DORAFCE_PG_RE_FLAGS_IN_REGEX_H` against the same IvorySQL headers: compiles clean.
- Patched, flag *not* passed, against the same IvorySQL headers: fails with the identical error (confirms the guard is what matters, not something else).
- Patched, flag not passed (default path everyone hits): full extension build (`make`, all 29 source files, final link) against vanilla PostgreSQL 17.11 — succeeds unchanged, `orafce.so` produced.

No behavior change for a normal PostgreSQL build; this only affects the alternate code path taken by `-DORAFCE_PG_RE_FLAGS_IN_REGEX_H`, which nothing defines today.