### PR TITLE
Add the UTL_RAW package

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,7 +93,8 @@ REGRESS = orafce\
 		dbms_random\
 		regexp_func\
 		dbms_sql\
-		hextoraw
+		hextoraw\
+		utl_raw
 
 #REGRESS_OPTS = --load-language=plpgsql --schedule=parallel_schedule --encoding=utf8
 REGRESS_OPTS = --schedule=parallel_schedule --encoding=utf8

--- a/expected/utl_raw.out
+++ b/expected/utl_raw.out
@@ -1,0 +1,109 @@
+-- Test for the UTL_RAW package
+\set ECHO none
+SET search_path TO utl_raw, oracle, "$user", public, pg_catalog;
+----
+-- CAST_TO_RAW() / CAST_TO_VARCHAR2() -- the database charset byte view of a string
+----
+-- ORACLE> SELECT UTL_RAW.CAST_TO_RAW('ABC') FROM dual; -> 414243
+SELECT rawtohex(utl_raw.cast_to_raw('ABC'));
+ rawtohex 
+----------
+ 414243
+(1 row)
+
+-- ORACLE> SELECT UTL_RAW.CAST_TO_VARCHAR2(HEXTORAW('414243')) FROM dual; -> ABC
+SELECT utl_raw.cast_to_varchar2(hextoraw('414243'));
+ cast_to_varchar2 
+------------------
+ ABC
+(1 row)
+
+-- inverse of each other, including a multibyte string
+SELECT utl_raw.cast_to_varchar2(utl_raw.cast_to_raw('Ångström'));
+ cast_to_varchar2 
+------------------
+ Ångström
+(1 row)
+
+----
+-- LENGTH() -- the number of bytes
+----
+-- ORACLE> SELECT UTL_RAW.LENGTH(HEXTORAW('DEADBEEF')) FROM dual; -> 4
+SELECT utl_raw.length(hextoraw('DEADBEEF'));
+ length 
+--------
+      4
+(1 row)
+
+SELECT utl_raw.length(hextoraw(''));
+ length 
+--------
+      0
+(1 row)
+
+----
+-- SUBSTR() -- 1-based, a negative position counts from the end, length optional
+----
+-- ORACLE> SELECT UTL_RAW.SUBSTR(HEXTORAW('DEADBEEF'), 2, 2) FROM dual; -> ADBE
+SELECT rawtohex(utl_raw.substr(hextoraw('DEADBEEF'), 2, 2));
+ rawtohex 
+----------
+ ADBE
+(1 row)
+
+-- omitted length runs to the end
+SELECT rawtohex(utl_raw.substr(hextoraw('DEADBEEF'), 3));
+ rawtohex 
+----------
+ BEEF
+(1 row)
+
+-- a negative position counts from the end
+SELECT rawtohex(utl_raw.substr(hextoraw('DEADBEEF'), -1));
+ rawtohex 
+----------
+ EF
+(1 row)
+
+----
+-- CONCAT() -- concatenate raw values
+----
+-- ORACLE> SELECT UTL_RAW.CONCAT(HEXTORAW('DEAD'), HEXTORAW('BEEF')) FROM dual; -> DEADBEEF
+SELECT rawtohex(utl_raw.concat(hextoraw('DEAD'), hextoraw('BEEF')));
+ rawtohex 
+----------
+ DEADBEEF
+(1 row)
+
+----
+-- BIT_AND() / BIT_OR() / BIT_XOR() -- byte-wise; the tail of the longer operand
+-- is appended once the shorter one runs out, as in Oracle
+----
+-- ORACLE> SELECT UTL_RAW.BIT_AND(HEXTORAW('F0F0'), HEXTORAW('FF00')) FROM dual; -> F000
+SELECT rawtohex(utl_raw.bit_and(hextoraw('F0F0'), hextoraw('FF00')));
+ rawtohex 
+----------
+ F000
+(1 row)
+
+-- ORACLE> SELECT UTL_RAW.BIT_OR(HEXTORAW('F000'), HEXTORAW('0F0F')) FROM dual; -> FF0F
+SELECT rawtohex(utl_raw.bit_or(hextoraw('F000'), hextoraw('0F0F')));
+ rawtohex 
+----------
+ FF0F
+(1 row)
+
+-- ORACLE> SELECT UTL_RAW.BIT_XOR(HEXTORAW('FF'), HEXTORAW('0F')) FROM dual; -> F0
+SELECT rawtohex(utl_raw.bit_xor(hextoraw('FF'), hextoraw('0F')));
+ rawtohex 
+----------
+ F0
+(1 row)
+
+-- unequal lengths: the unprocessed tail of the longer operand is appended
+SELECT rawtohex(utl_raw.bit_and(hextoraw('FFFF'), hextoraw('F0')));
+ rawtohex 
+----------
+ F0FF
+(1 row)
+

--- a/orafce--4.16--4.17.sql
+++ b/orafce--4.16--4.17.sql
@@ -36,3 +36,110 @@ AS $$
 $$
 LANGUAGE sql STABLE STRICT PARALLEL SAFE;
 COMMENT ON FUNCTION oracle.from_tz(timestamp, text) IS 'Interprets a timestamp as being in the given time zone and returns a timestamp with time zone';
+
+-- UTL_RAW: Oracle's RAW/bytea manipulation package. CAST_TO_RAW / CAST_TO_VARCHAR2
+-- use the database character set (like Oracle, which uses the database charset for
+-- the VARCHAR2<->RAW casts). The bitwise operators follow Oracle's rule that, when
+-- the operands differ in length, the operation stops at the end of the shorter one
+-- and the unprocessed tail of the longer is appended to the result.
+CREATE SCHEMA utl_raw;
+
+CREATE FUNCTION utl_raw.cast_to_raw(text)
+RETURNS bytea
+AS $$ SELECT convert_to($1, current_setting('server_encoding')) $$
+LANGUAGE sql STABLE STRICT PARALLEL SAFE;
+COMMENT ON FUNCTION utl_raw.cast_to_raw(text) IS 'Converts a value to a raw (bytea) value using the database character set';
+
+CREATE FUNCTION utl_raw.cast_to_varchar2(bytea)
+RETURNS text
+AS $$ SELECT convert_from($1, current_setting('server_encoding')) $$
+LANGUAGE sql STABLE STRICT PARALLEL SAFE;
+COMMENT ON FUNCTION utl_raw.cast_to_varchar2(bytea) IS 'Converts a raw (bytea) value to a value using the database character set';
+
+CREATE FUNCTION utl_raw.length(bytea)
+RETURNS integer
+AS $$ SELECT pg_catalog.length($1) $$
+LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE;
+COMMENT ON FUNCTION utl_raw.length(bytea) IS 'Returns the number of bytes in a raw (bytea) value';
+
+CREATE FUNCTION utl_raw.substr(bytea, integer, integer DEFAULT NULL)
+RETURNS bytea
+AS $$
+    -- Oracle UTL_RAW.SUBSTR is 1-based; a negative position counts from the end,
+    -- and an omitted length runs to the end of the value.
+    SELECT CASE
+        WHEN $2 = 0 THEN NULL
+        WHEN $2 < 0 THEN substring($1 FROM pg_catalog.length($1) + $2 + 1 FOR coalesce($3, pg_catalog.length($1)))
+        ELSE substring($1 FROM $2 FOR coalesce($3, pg_catalog.length($1)))
+    END
+$$
+LANGUAGE sql IMMUTABLE PARALLEL SAFE;
+COMMENT ON FUNCTION utl_raw.substr(bytea, integer, integer) IS 'Returns a portion of a raw (bytea) value';
+
+CREATE FUNCTION utl_raw.concat(VARIADIC bytea[])
+RETURNS bytea
+AS $$ SELECT coalesce(string_agg(part, ''::bytea), ''::bytea) FROM unnest($1) AS part $$
+LANGUAGE sql IMMUTABLE PARALLEL SAFE;
+COMMENT ON FUNCTION utl_raw.concat(VARIADIC bytea[]) IS 'Concatenates raw (bytea) values';
+
+CREATE FUNCTION utl_raw.bit_and(bytea, bytea)
+RETURNS bytea
+AS $$
+DECLARE
+    n integer := least(pg_catalog.length($1), pg_catalog.length($2));
+    result bytea := ''::bytea;
+    i integer;
+BEGIN
+    FOR i IN 0 .. n - 1 LOOP
+        result := result || decode(lpad(to_hex(get_byte($1, i) & get_byte($2, i)), 2, '0'), 'hex');
+    END LOOP;
+    IF pg_catalog.length($1) > n THEN result := result || substring($1 FROM n + 1);
+    ELSIF pg_catalog.length($2) > n THEN result := result || substring($2 FROM n + 1);
+    END IF;
+    RETURN result;
+END
+$$
+LANGUAGE plpgsql IMMUTABLE PARALLEL SAFE;
+COMMENT ON FUNCTION utl_raw.bit_and(bytea, bytea) IS 'Bitwise AND of two raw (bytea) values';
+
+CREATE FUNCTION utl_raw.bit_or(bytea, bytea)
+RETURNS bytea
+AS $$
+DECLARE
+    n integer := least(pg_catalog.length($1), pg_catalog.length($2));
+    result bytea := ''::bytea;
+    i integer;
+BEGIN
+    FOR i IN 0 .. n - 1 LOOP
+        result := result || decode(lpad(to_hex(get_byte($1, i) | get_byte($2, i)), 2, '0'), 'hex');
+    END LOOP;
+    IF pg_catalog.length($1) > n THEN result := result || substring($1 FROM n + 1);
+    ELSIF pg_catalog.length($2) > n THEN result := result || substring($2 FROM n + 1);
+    END IF;
+    RETURN result;
+END
+$$
+LANGUAGE plpgsql IMMUTABLE PARALLEL SAFE;
+COMMENT ON FUNCTION utl_raw.bit_or(bytea, bytea) IS 'Bitwise OR of two raw (bytea) values';
+
+CREATE FUNCTION utl_raw.bit_xor(bytea, bytea)
+RETURNS bytea
+AS $$
+DECLARE
+    n integer := least(pg_catalog.length($1), pg_catalog.length($2));
+    result bytea := ''::bytea;
+    i integer;
+BEGIN
+    FOR i IN 0 .. n - 1 LOOP
+        result := result || decode(lpad(to_hex(get_byte($1, i) # get_byte($2, i)), 2, '0'), 'hex');
+    END LOOP;
+    IF pg_catalog.length($1) > n THEN result := result || substring($1 FROM n + 1);
+    ELSIF pg_catalog.length($2) > n THEN result := result || substring($2 FROM n + 1);
+    END IF;
+    RETURN result;
+END
+$$
+LANGUAGE plpgsql IMMUTABLE PARALLEL SAFE;
+COMMENT ON FUNCTION utl_raw.bit_xor(bytea, bytea) IS 'Bitwise XOR of two raw (bytea) values';
+
+GRANT USAGE ON SCHEMA utl_raw TO PUBLIC;

--- a/orafce--4.17.sql
+++ b/orafce--4.17.sql
@@ -4394,3 +4394,110 @@ BEGIN
   END IF;
 END;
 $$;
+
+-- UTL_RAW: Oracle's RAW/bytea manipulation package. CAST_TO_RAW / CAST_TO_VARCHAR2
+-- use the database character set (like Oracle, which uses the database charset for
+-- the VARCHAR2<->RAW casts). The bitwise operators follow Oracle's rule that, when
+-- the operands differ in length, the operation stops at the end of the shorter one
+-- and the unprocessed tail of the longer is appended to the result.
+CREATE SCHEMA utl_raw;
+
+CREATE FUNCTION utl_raw.cast_to_raw(text)
+RETURNS bytea
+AS $$ SELECT convert_to($1, current_setting('server_encoding')) $$
+LANGUAGE sql STABLE STRICT PARALLEL SAFE;
+COMMENT ON FUNCTION utl_raw.cast_to_raw(text) IS 'Converts a value to a raw (bytea) value using the database character set';
+
+CREATE FUNCTION utl_raw.cast_to_varchar2(bytea)
+RETURNS text
+AS $$ SELECT convert_from($1, current_setting('server_encoding')) $$
+LANGUAGE sql STABLE STRICT PARALLEL SAFE;
+COMMENT ON FUNCTION utl_raw.cast_to_varchar2(bytea) IS 'Converts a raw (bytea) value to a value using the database character set';
+
+CREATE FUNCTION utl_raw.length(bytea)
+RETURNS integer
+AS $$ SELECT pg_catalog.length($1) $$
+LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE;
+COMMENT ON FUNCTION utl_raw.length(bytea) IS 'Returns the number of bytes in a raw (bytea) value';
+
+CREATE FUNCTION utl_raw.substr(bytea, integer, integer DEFAULT NULL)
+RETURNS bytea
+AS $$
+    -- Oracle UTL_RAW.SUBSTR is 1-based; a negative position counts from the end,
+    -- and an omitted length runs to the end of the value.
+    SELECT CASE
+        WHEN $2 = 0 THEN NULL
+        WHEN $2 < 0 THEN substring($1 FROM pg_catalog.length($1) + $2 + 1 FOR coalesce($3, pg_catalog.length($1)))
+        ELSE substring($1 FROM $2 FOR coalesce($3, pg_catalog.length($1)))
+    END
+$$
+LANGUAGE sql IMMUTABLE PARALLEL SAFE;
+COMMENT ON FUNCTION utl_raw.substr(bytea, integer, integer) IS 'Returns a portion of a raw (bytea) value';
+
+CREATE FUNCTION utl_raw.concat(VARIADIC bytea[])
+RETURNS bytea
+AS $$ SELECT coalesce(string_agg(part, ''::bytea), ''::bytea) FROM unnest($1) AS part $$
+LANGUAGE sql IMMUTABLE PARALLEL SAFE;
+COMMENT ON FUNCTION utl_raw.concat(VARIADIC bytea[]) IS 'Concatenates raw (bytea) values';
+
+CREATE FUNCTION utl_raw.bit_and(bytea, bytea)
+RETURNS bytea
+AS $$
+DECLARE
+    n integer := least(pg_catalog.length($1), pg_catalog.length($2));
+    result bytea := ''::bytea;
+    i integer;
+BEGIN
+    FOR i IN 0 .. n - 1 LOOP
+        result := result || decode(lpad(to_hex(get_byte($1, i) & get_byte($2, i)), 2, '0'), 'hex');
+    END LOOP;
+    IF pg_catalog.length($1) > n THEN result := result || substring($1 FROM n + 1);
+    ELSIF pg_catalog.length($2) > n THEN result := result || substring($2 FROM n + 1);
+    END IF;
+    RETURN result;
+END
+$$
+LANGUAGE plpgsql IMMUTABLE PARALLEL SAFE;
+COMMENT ON FUNCTION utl_raw.bit_and(bytea, bytea) IS 'Bitwise AND of two raw (bytea) values';
+
+CREATE FUNCTION utl_raw.bit_or(bytea, bytea)
+RETURNS bytea
+AS $$
+DECLARE
+    n integer := least(pg_catalog.length($1), pg_catalog.length($2));
+    result bytea := ''::bytea;
+    i integer;
+BEGIN
+    FOR i IN 0 .. n - 1 LOOP
+        result := result || decode(lpad(to_hex(get_byte($1, i) | get_byte($2, i)), 2, '0'), 'hex');
+    END LOOP;
+    IF pg_catalog.length($1) > n THEN result := result || substring($1 FROM n + 1);
+    ELSIF pg_catalog.length($2) > n THEN result := result || substring($2 FROM n + 1);
+    END IF;
+    RETURN result;
+END
+$$
+LANGUAGE plpgsql IMMUTABLE PARALLEL SAFE;
+COMMENT ON FUNCTION utl_raw.bit_or(bytea, bytea) IS 'Bitwise OR of two raw (bytea) values';
+
+CREATE FUNCTION utl_raw.bit_xor(bytea, bytea)
+RETURNS bytea
+AS $$
+DECLARE
+    n integer := least(pg_catalog.length($1), pg_catalog.length($2));
+    result bytea := ''::bytea;
+    i integer;
+BEGIN
+    FOR i IN 0 .. n - 1 LOOP
+        result := result || decode(lpad(to_hex(get_byte($1, i) # get_byte($2, i)), 2, '0'), 'hex');
+    END LOOP;
+    IF pg_catalog.length($1) > n THEN result := result || substring($1 FROM n + 1);
+    ELSIF pg_catalog.length($2) > n THEN result := result || substring($2 FROM n + 1);
+    END IF;
+    RETURN result;
+END
+$$
+LANGUAGE plpgsql IMMUTABLE PARALLEL SAFE;
+COMMENT ON FUNCTION utl_raw.bit_xor(bytea, bytea) IS 'Bitwise XOR of two raw (bytea) values';
+
+GRANT USAGE ON SCHEMA utl_raw TO PUBLIC;

--- a/sql/utl_raw.sql
+++ b/sql/utl_raw.sql
@@ -1,0 +1,59 @@
+-- Test for the UTL_RAW package
+\set ECHO none
+SET client_min_messages = warning;
+SET client_encoding = utf8;
+\set VERBOSITY terse
+\set ECHO all
+
+SET search_path TO utl_raw, oracle, "$user", public, pg_catalog;
+
+----
+-- CAST_TO_RAW() / CAST_TO_VARCHAR2() -- the database charset byte view of a string
+----
+
+-- ORACLE> SELECT UTL_RAW.CAST_TO_RAW('ABC') FROM dual; -> 414243
+SELECT rawtohex(utl_raw.cast_to_raw('ABC'));
+-- ORACLE> SELECT UTL_RAW.CAST_TO_VARCHAR2(HEXTORAW('414243')) FROM dual; -> ABC
+SELECT utl_raw.cast_to_varchar2(hextoraw('414243'));
+-- inverse of each other, including a multibyte string
+SELECT utl_raw.cast_to_varchar2(utl_raw.cast_to_raw('Ångström'));
+
+----
+-- LENGTH() -- the number of bytes
+----
+
+-- ORACLE> SELECT UTL_RAW.LENGTH(HEXTORAW('DEADBEEF')) FROM dual; -> 4
+SELECT utl_raw.length(hextoraw('DEADBEEF'));
+SELECT utl_raw.length(hextoraw(''));
+
+----
+-- SUBSTR() -- 1-based, a negative position counts from the end, length optional
+----
+
+-- ORACLE> SELECT UTL_RAW.SUBSTR(HEXTORAW('DEADBEEF'), 2, 2) FROM dual; -> ADBE
+SELECT rawtohex(utl_raw.substr(hextoraw('DEADBEEF'), 2, 2));
+-- omitted length runs to the end
+SELECT rawtohex(utl_raw.substr(hextoraw('DEADBEEF'), 3));
+-- a negative position counts from the end
+SELECT rawtohex(utl_raw.substr(hextoraw('DEADBEEF'), -1));
+
+----
+-- CONCAT() -- concatenate raw values
+----
+
+-- ORACLE> SELECT UTL_RAW.CONCAT(HEXTORAW('DEAD'), HEXTORAW('BEEF')) FROM dual; -> DEADBEEF
+SELECT rawtohex(utl_raw.concat(hextoraw('DEAD'), hextoraw('BEEF')));
+
+----
+-- BIT_AND() / BIT_OR() / BIT_XOR() -- byte-wise; the tail of the longer operand
+-- is appended once the shorter one runs out, as in Oracle
+----
+
+-- ORACLE> SELECT UTL_RAW.BIT_AND(HEXTORAW('F0F0'), HEXTORAW('FF00')) FROM dual; -> F000
+SELECT rawtohex(utl_raw.bit_and(hextoraw('F0F0'), hextoraw('FF00')));
+-- ORACLE> SELECT UTL_RAW.BIT_OR(HEXTORAW('F000'), HEXTORAW('0F0F')) FROM dual; -> FF0F
+SELECT rawtohex(utl_raw.bit_or(hextoraw('F000'), hextoraw('0F0F')));
+-- ORACLE> SELECT UTL_RAW.BIT_XOR(HEXTORAW('FF'), HEXTORAW('0F')) FROM dual; -> F0
+SELECT rawtohex(utl_raw.bit_xor(hextoraw('FF'), hextoraw('0F')));
+-- unequal lengths: the unprocessed tail of the longer operand is appended
+SELECT rawtohex(utl_raw.bit_and(hextoraw('FFFF'), hextoraw('F0')));


### PR DESCRIPTION
UTL_RAW is Oracle's RAW (bytea) manipulation package, and orafce did not have it. Add it as SQL functions in a new utl_raw schema, into the current development version 4.17 (the full install orafce--4.17.sql and the orafce--4.16--4.17.sql migration), the same way hextoraw/rawtohex were added:

- CAST_TO_RAW(text) / CAST_TO_VARCHAR2(bytea) — the byte view of a value in the database character set (Oracle uses the database charset for these casts), via convert_to / convert_from over current_setting('server_encoding').
- LENGTH(bytea) — the number of bytes.
- SUBSTR(bytea, pos [, len]) — 1-based, a negative position counts from the end, an omitted length runs to the end.
- CONCAT(VARIADIC bytea[]) — concatenate raw values.
- BIT_AND / BIT_OR / BIT_XOR(bytea, bytea) — byte-wise; when the operands differ in length the operation stops at the end of the shorter one and the unprocessed tail of the longer is appended to the result, as Oracle does.

The function bodies schema-qualify pg_catalog.length so a caller that has utl_raw on its search_path does not recurse into utl_raw.length itself.

A regression test (sql/utl_raw.sql, added to REGRESS) exercises every function, including the CAST round-trip over a multibyte string, SUBSTR's negative position, and the bit operators' tail behaviour on unequal lengths. Each case carries the ORACLE> query and result it mirrors.